### PR TITLE
Allow architecture validator to fetch layer from inferred root

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.0.7)
+    packwerk-extensions (0.0.8)
       packwerk (>= 2.2.1)
       rails
       sorbet-runtime

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.0.7'
+  spec.version       = '0.0.8'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/unit/architecture/validator_test.rb
+++ b/test/unit/architecture/validator_test.rb
@@ -91,6 +91,12 @@ module Packwerk
         assert result.ok?
       end
 
+      test 'call returns no error for no layer value if layer is implied by root location' do
+        merge_into_app_yaml_file('utility/package.yml', { 'enforce_architecture' => true })
+        result = validator.call(package_set, config)
+        assert result.ok?
+      end
+
       test 'call returns an error if a dependency violates architecture layers' do
         merge_into_app_yaml_file('packs/my_utility/package.yml', { 'dependencies' => ['packs/my_pack'], 'enforce_architecture' => true, 'layer' => 'utility' })
         merge_into_app_yaml_file('packs/my_pack/package.yml', { 'enforce_architecture' => false, 'layer' => 'package' })


### PR DESCRIPTION
This fixes a bug leading to a validation error if pack layer can be inferred from root.
