### PR TITLE
Fix bug with architecture validator if layers not set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.0.8)
+    packwerk-extensions (0.0.9)
       packwerk (>= 2.2.1)
       rails
       sorbet-runtime

--- a/lib/packwerk/architecture/validator.rb
+++ b/lib/packwerk/architecture/validator.rb
@@ -91,20 +91,21 @@ module Packwerk
         params(config_file_path: String, setting: T.untyped).returns(Result)
       end
       def check_enforce_architecture_setting(config_file_path, setting)
+        activated_value = [true, 'strict'].include?(setting)
         valid_value = [true, nil, false, 'strict'].include?(setting)
         layers_set = layers.names.any?
-        if valid_value && layers_set
-          Result.new(ok: true)
-        elsif valid_value
+        if !valid_value
+          Result.new(
+            ok: false,
+            error_value: "Invalid 'enforce_architecture' option in #{config_file_path.inspect}: #{setting.inspect}"
+          )
+        elsif activated_value && !layers_set
           Result.new(
             ok: false,
             error_value: "Cannot set 'enforce_architecture' option in #{config_file_path.inspect} until `architectural_layers` have been specified in `packwerk.yml`"
           )
         else
-          Result.new(
-            ok: false,
-            error_value: "Invalid 'enforce_architecture' option in #{config_file_path.inspect}: #{setting.inspect}"
-          )
+          Result.new(ok: true)
         end
       end
     end

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.0.8'
+  spec.version       = '0.0.9'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/unit/architecture/validator_test.rb
+++ b/test/unit/architecture/validator_test.rb
@@ -30,7 +30,7 @@ module Packwerk
 
       test 'call returns no error if enforce_architecture is unset' do
         write_app_file('packwerk.yml', <<~YML)
-        {}
+          {}
         YML
         result = validator.call(package_set, config)
 

--- a/test/unit/architecture/validator_test.rb
+++ b/test/unit/architecture/validator_test.rb
@@ -28,6 +28,15 @@ module Packwerk
         teardown_application_fixture
       end
 
+      test 'call returns no error if enforce_architecture is unset' do
+        write_app_file('packwerk.yml', <<~YML)
+        {}
+        YML
+        result = validator.call(package_set, config)
+
+        assert result.ok?
+      end
+
       test 'call returns an error for invalid enforce_visibility value' do
         merge_into_app_yaml_file('package.yml', { 'enforce_architecture' => 'yes, please.' })
 


### PR DESCRIPTION
The validator had a false negative if layers were unset. This fixes that.
