### PR TITLE
Fix privacy checker for named constants

### DIFF
--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -27,7 +27,7 @@ module Packwerk
         return false if privacy_package.public_path?(reference.constant.location)
 
         privacy_option = privacy_package.enforce_privacy
-        !enforcement_disabled?(privacy_option)
+        !enforcement_disabled?(privacy_option, reference.constant)
       end
 
       sig do
@@ -61,11 +61,17 @@ module Packwerk
       private
 
       sig do
-        params(privacy_option: T.nilable(T.any(T::Boolean, String, T::Array[String])))
+        params(privacy_option: T.nilable(T.any(T::Boolean, String, T::Array[String])), constant: Packwerk::ConstantContext)
           .returns(T::Boolean)
       end
-      def enforcement_disabled?(privacy_option)
-        [false, nil].include?(privacy_option)
+      def enforcement_disabled?(privacy_option, constant)
+        return true if [false, nil].include?(privacy_option)
+        return false unless privacy_option.is_a?(Array)
+
+        names = constant.name.split('::')
+        names_to_check = names.count.times.map { |i| names[0..i].join('::') }
+
+        (privacy_option & names_to_check).empty?
       end
 
       sig { params(reference: Reference).returns(String) }

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -44,7 +44,7 @@ module Packwerk
       test 'complains about nested constant if enforcing for specific constants' do
         destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
         checker = privacy_checker
-        reference = build_reference(destination_package: destination_package)
+        reference = build_reference(destination_package: destination_package, constant_name: '::SomeName::NestedName')
 
         assert checker.invalid_reference?(reference)
       end

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -41,6 +41,14 @@ module Packwerk
         assert checker.invalid_reference?(reference)
       end
 
+      test 'ignores unlisted private constants if enforcing for specific constants' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package, constant_name: '::SomeOtherName')
+
+        refute checker.invalid_reference?(reference)
+      end
+
       test 'complains about nested constant if enforcing for specific constants' do
         destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
         checker = privacy_checker


### PR DESCRIPTION
Named constant violations were being correctly reported, but unfortunately so were all other private constants in the package. This PR fixes this and adds a test to prevent regressions. I also fixed the test for nested constants. Both these changes should match the previous behaviour when privacy enforcement was part of Packwerk.