### PR TITLE
Allow independently instantiating checkers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.0.9)
+    packwerk-extensions (0.0.10)
       packwerk (>= 2.2.1)
       rails
       sorbet-runtime
@@ -107,7 +107,7 @@ GEM
     date (3.3.3)
     diff-lcs (1.5.0)
     erubi (1.11.0)
-    globalid (1.0.0)
+    globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -115,7 +115,7 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -127,7 +127,7 @@ GEM
     minitest (5.16.3)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.3.2)
+    net-imap (0.3.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -141,10 +141,6 @@ GEM
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.9-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.9-x86_64-darwin)
-      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -152,7 +148,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     racc (1.6.0)
-    rack (2.2.4)
+    rack (2.2.6.2)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Currently, it ships the following checkers to help improve the boundaries betwee
 - A `visibility` checker that allows packages to be private except to an explicit group of other packages.
 - An experimental `architecture` checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
 
+## Installation
+
+To register all checkers included in this gem, add the following to your `packwerk.yml`:
+
+```yaml
+require: packwerk-extensions
+```
+
+Alternatively, you can require individual checkers:
+
+```yaml
+require:
+  - packwerk/privacy/checker
+  - packwerk/visibility/checker
+  - packwerk/architecture/checker
+```
+
 ## Privacy Checker
 The privacy checker extension was originally extracted from [packwerk](https://github.com/Shopify/packwerk).
 

--- a/lib/packwerk-extensions.rb
+++ b/lib/packwerk-extensions.rb
@@ -5,16 +5,8 @@ require 'sorbet-runtime'
 require 'packwerk'
 
 require 'packwerk/privacy/checker'
-require 'packwerk/privacy/package'
-require 'packwerk/privacy/validator'
-
 require 'packwerk/visibility/checker'
-require 'packwerk/visibility/package'
-require 'packwerk/visibility/validator'
-
 require 'packwerk/architecture/checker'
-require 'packwerk/architecture/package'
-require 'packwerk/architecture/validator'
 
 module Packwerk
   module Extensions

--- a/lib/packwerk/architecture/checker.rb
+++ b/lib/packwerk/architecture/checker.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require 'packwerk/architecture/layers'
+require 'packwerk/architecture/package'
+require 'packwerk/architecture/validator'
 
 module Packwerk
   module Architecture

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -1,6 +1,9 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'packwerk/privacy/package'
+require 'packwerk/privacy/validator'
+
 module Packwerk
   module Privacy
     # Checks whether a given reference references a private constant of another package.

--- a/lib/packwerk/visibility/checker.rb
+++ b/lib/packwerk/visibility/checker.rb
@@ -1,6 +1,9 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'packwerk/visibility/package'
+require 'packwerk/visibility/validator'
+
 module Packwerk
   module Visibility
     # Checks whether a given reference references a constant from a package that does not permit visibility

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.0.9'
+  spec.version       = '0.0.10'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
While setting up the privacy checker I was getting errors due to missing `packwerk.yml` which is expected by the architecture checker. You see, at GitHub we still are instantiating Packwerk programmatically, at least until I'm done migrating to the main branch.

So initially I was going to fix that assumption, but then I realized why is architecture checker even running, I never set it up! Well this is because Packwerk registers checkers when a class is loaded that includes the `Packwerk::Checker` module. So to remove that checker, we need to stop loading the checkers.

This PR rearranges the `require` directives so that each checker can be required independently, and requiring the gem just requires all the checkers. This lets users of the gem pick and choose whatever bits they need for their projects.