### PR TITLE
Support list of private constants

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.0.11)
+    packwerk-extensions (0.1.0)
       packwerk (>= 2.2.1)
       railties (>= 6.0.0)
       sorbet-runtime

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Example:
 public_path: my/custom/path/
 ```
 
+### Using specific private constants
+Sometimes it is desirable to only enforce privacy on a subset of constants in a package. You can do so by defining a `private_constants` list in your package.yml. Note that `enforce_privacy` must be set to `true` or `'strict'` for this to work.
+
 ### Package Privacy violation
 A constant that is private to its package has been referenced from outside of the package. Constants are declared private in their package’s `package.yml`.
 

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -32,10 +32,7 @@ module Packwerk
         privacy_option = privacy_package.enforce_privacy
         return false if enforcement_disabled?(privacy_option)
 
-        return false unless privacy_option == true || privacy_option == 'strict' ||
-                            explicitly_private_constant?(reference.constant, explicitly_private_constants: T.unsafe(privacy_option))
-
-        true
+        explicitly_private_constant?(reference.constant, explicitly_private_constants: privacy_package.private_constants)
       end
 
       sig do
@@ -75,6 +72,8 @@ module Packwerk
         ).returns(T::Boolean)
       end
       def explicitly_private_constant?(constant, explicitly_private_constants:)
+        return true if explicitly_private_constants.empty?
+
         explicitly_private_constants.include?(constant.name) ||
           # nested constants
           explicitly_private_constants.any? { |epc| constant.name.start_with?("#{epc}::") }

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -30,7 +30,12 @@ module Packwerk
         return false if privacy_package.public_path?(reference.constant.location)
 
         privacy_option = privacy_package.enforce_privacy
-        !enforcement_disabled?(privacy_option)
+        return false if enforcement_disabled?(privacy_option)
+
+        return false unless privacy_option == true || privacy_option == 'strict' ||
+                            explicitly_private_constant?(reference.constant, explicitly_private_constants: T.unsafe(privacy_option))
+
+        true
       end
 
       sig do
@@ -62,6 +67,18 @@ module Packwerk
       end
 
       private
+
+      sig do
+        params(
+          constant: ConstantContext,
+          explicitly_private_constants: T::Array[String]
+        ).returns(T::Boolean)
+      end
+      def explicitly_private_constant?(constant, explicitly_private_constants:)
+        explicitly_private_constants.include?(constant.name) ||
+          # nested constants
+          explicitly_private_constants.any? { |epc| constant.name.start_with?("#{epc}::") }
+      end
 
       sig do
         params(privacy_option: T.nilable(T.any(T::Boolean, String, T::Array[String])))

--- a/lib/packwerk/privacy/package.rb
+++ b/lib/packwerk/privacy/package.rb
@@ -8,7 +8,8 @@ module Packwerk
 
       const :public_path, String
       const :user_defined_public_path, T.nilable(String)
-      const :enforce_privacy, T.nilable(T.any(T::Boolean, String, T::Array[String]))
+      const :enforce_privacy, T.nilable(T.any(T::Boolean, String))
+      const :private_constants, T::Array[String]
 
       sig { params(path: String).returns(T::Boolean) }
       def public_path?(path)
@@ -23,7 +24,8 @@ module Packwerk
           Package.new(
             public_path: public_path_for(package),
             user_defined_public_path: user_defined_public_path(package),
-            enforce_privacy: package.config['enforce_privacy']
+            enforce_privacy: package.config['enforce_privacy'],
+            private_constants: package.config['private_constants'] || []
           )
         end
 

--- a/lib/packwerk/privacy/validator.rb
+++ b/lib/packwerk/privacy/validator.rb
@@ -15,8 +15,29 @@ module Packwerk
 
         results = T.let([], T::Array[Result])
 
+        resolver = ConstantResolver.new(
+          root_path: configuration.root_path,
+          load_paths: configuration.load_paths
+        )
+
         privacy_settings.each do |config_file_path, setting|
           results << check_enforce_privacy_setting(config_file_path, setting)
+
+          next unless setting.is_a?(Array)
+
+          constants = setting
+
+          results += assert_constants_can_be_loaded(constants, config_file_path)
+
+          constant_locations = constants.map { |c| [c, resolver.resolve(c)&.location] }
+
+          constant_locations.each do |name, location|
+            results << if location
+                         check_private_constant_location(configuration, package_set, name, location, config_file_path)
+                       else
+                         private_constant_unresolvable(name, config_file_path)
+                       end
+          end
         end
 
         public_path_settings = package_manifests_settings_for(configuration, 'public_path')
@@ -60,6 +81,55 @@ module Packwerk
             error_value: "Invalid 'enforce_privacy' option in #{config_file_path.inspect}: #{setting.inspect}"
           )
         end
+      end
+
+      sig do
+        params(configuration: Configuration, package_set: PackageSet, name: T.untyped, location: T.untyped,
+               config_file_path: T.untyped).returns(Result)
+      end
+      def check_private_constant_location(configuration, package_set, name, location, config_file_path)
+        declared_package = package_set.package_from_path(relative_path(configuration, config_file_path))
+        constant_package = package_set.package_from_path(location)
+
+        if constant_package == declared_package
+          Result.new(ok: true)
+        else
+          Result.new(
+            ok: false,
+            error_value: "'#{name}' is declared as private in the '#{declared_package}' package but appears to be " \
+                         "defined\nin the '#{constant_package}' package. Packwerk resolved it to #{location}."
+          )
+        end
+      end
+
+      sig { params(constants: T.untyped, config_file_path: String).returns(T::Array[Result]) }
+      def assert_constants_can_be_loaded(constants, config_file_path)
+        constants.map do |constant|
+          if constant.start_with?('::')
+            constant.try(&:constantize) && Result.new(ok: true)
+          else
+            error_value = "'#{constant}', listed in the 'enforce_privacy' option " \
+                          "in #{config_file_path}, is invalid.\nPrivate constants need to be " \
+                          'prefixed with the top-level namespace operator `::`.'
+            Result.new(
+              ok: false,
+              error_value: error_value
+            )
+          end
+        end
+      end
+
+      sig { params(name: T.untyped, config_file_path: T.untyped).returns(Result) }
+      def private_constant_unresolvable(name, config_file_path)
+        explicit_filepath = "#{(name.start_with?('::') ? name[2..] : name).underscore}.rb"
+
+        Result.new(
+          ok: false,
+          error_value: "'#{name}', listed in #{config_file_path}, could not be resolved.\n" \
+                       "This is probably because it is an autovivified namespace - a namespace module that doesn't have a\n" \
+                       "file explicitly defining it. Packwerk currently doesn't support declaring autovivified namespaces as\n" \
+                       "private. Add a #{explicit_filepath} file to explicitly define the constant."
+        )
       end
     end
   end

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.0.11'
+  spec.version       = '0.1.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/fixtures/skeleton/components/timeline/package.yml
+++ b/test/fixtures/skeleton/components/timeline/package.yml
@@ -1,2 +1,3 @@
-enforce_privacy:
+enforce_privacy: true
+private_constants:
   - "::PrivateThing"

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -19,8 +19,12 @@ module Packwerk
       end
 
       test 'ignores if destination package is not enforcing' do
+        destination_package = Packwerk::Package.new(
+          name: 'destination_package',
+          config: { 'enforce_privacy' => false, 'private_constants' => ['::SomeName'] }
+        )
         checker = privacy_checker
-        reference = build_reference
+        reference = build_reference(destination_package: destination_package)
 
         refute checker.invalid_reference?(reference)
       end
@@ -28,7 +32,7 @@ module Packwerk
       test 'ignores if destination package is only enforcing for other constants' do
         destination_package = Packwerk::Package.new(
           name: 'destination_package',
-          config: { 'enforce_privacy' => ['::OtherConstant'] }
+          config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeOtherConstant'] }
         )
         checker = privacy_checker
         reference = build_reference(destination_package: destination_package)
@@ -45,7 +49,7 @@ module Packwerk
       end
 
       test 'complains about private constant if enforcing for specific constants' do
-        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeName'] })
         checker = privacy_checker
         reference = build_reference(destination_package: destination_package)
 
@@ -53,15 +57,15 @@ module Packwerk
       end
 
       test 'complains about nested constant if enforcing for specific constants' do
-        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeName'] })
         checker = privacy_checker
-        reference = build_reference(destination_package: destination_package)
+        reference = build_reference(destination_package: destination_package, constant_name: '::SomeName::Nested')
 
         assert checker.invalid_reference?(reference)
       end
 
       test 'ignores constant that starts like enforced constant' do
-        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeName'] })
         checker = privacy_checker
         reference = build_reference(destination_package: destination_package, constant_name: '::SomeNameButNotQuite')
 
@@ -77,7 +81,7 @@ module Packwerk
       end
 
       test 'only checks the package TODO file for private constants' do
-        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeName'] })
         checker = privacy_checker
         reference = build_reference(destination_package: destination_package)
 

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -25,6 +25,17 @@ module Packwerk
         refute checker.invalid_reference?(reference)
       end
 
+      test 'ignores if destination package is only enforcing for other constants' do
+        destination_package = Packwerk::Package.new(
+          name: 'destination_package',
+          config: { 'enforce_privacy' => ['::OtherConstant'] }
+        )
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package)
+
+        refute checker.invalid_reference?(reference)
+      end
+
       test 'complains about private constant if enforcing privacy for everything' do
         destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true })
         checker = privacy_checker
@@ -47,6 +58,14 @@ module Packwerk
         reference = build_reference(destination_package: destination_package)
 
         assert checker.invalid_reference?(reference)
+      end
+
+      test 'ignores constant that starts like enforced constant' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => ['::SomeName'] })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package, constant_name: '::SomeNameButNotQuite')
+
+        refute checker.invalid_reference?(reference)
       end
 
       test 'ignores public constant even if enforcing privacy for everything' do

--- a/test/unit/privacy/package_test.rb
+++ b/test/unit/privacy/package_test.rb
@@ -12,7 +12,7 @@ module Packwerk
 
       setup do
         setup_application_fixture
-        @package = Packwerk::Package.new(name: 'components/timeline', config: { 'enforce_privacy' => ['::Test'] })
+        @package = Packwerk::Package.new(name: 'components/timeline', config: { 'enforce_privacy' => true, 'private_constants' => ['::Test'] })
       end
 
       teardown do
@@ -25,7 +25,7 @@ module Packwerk
       end
 
       test '#enforce_privacy returns same value as from config' do
-        assert_equal(['::Test'], privacy_package.enforce_privacy)
+        assert_equal(true, privacy_package.enforce_privacy)
       end
 
       test '#public_path returns expected path when using the default public path' do

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -49,6 +49,60 @@ module Packwerk
       assert_match(/'public_path' option must be a string/, result.error_value)
     end
 
+    test 'check_package_manifests_for_privacy returns an error for unresolvable privatized constants' do
+      use_template(:skeleton)
+      ConstantResolver.expects(:new).returns(stub('resolver', resolve: nil))
+
+      result = Packwerk::Privacy::Validator.new.call(package_set, config)
+      refute result.ok?, result.error_value
+      assert_match(
+        /'::PrivateThing', listed in #{to_app_path('components\/timeline\/package.yml')}, could not be resolved/,
+        result.error_value
+      )
+      assert_match(
+        /Add a private_thing.rb file/,
+        result.error_value
+      )
+    end
+
+    test 'check_package_manifests_for_privacy returns an error for privatized constants in other packages' do
+      use_template(:skeleton)
+      context = ConstantResolver::ConstantContext.new('::PrivateThing', 'private_thing.rb')
+
+      ConstantResolver.expects(:new).returns(stub('resolver', resolve: context))
+
+      result = Packwerk::Privacy::Validator.new.call(package_set, config)
+
+      refute result.ok?, result.error_value
+      assert_match(
+        %r{'::PrivateThing' is declared as private in the 'components/timeline' package},
+        result.error_value
+      )
+      assert_match(
+        /but appears to be defined\sin the '.' package/,
+        result.error_value
+      )
+    end
+
+    test 'check_package_manifests_for_privacy returns an error for constants without `::` prefix' do
+      use_template(:minimal)
+      merge_into_app_yaml_file('package.yml', { 'enforce_privacy' => ['::PrivateThing', 'OtherThing'] })
+
+      result = Packwerk::Privacy::Validator.new.call(package_set, config)
+
+      refute result.ok?, result.error_value
+      assert_match(
+        /'OtherThing', listed in the 'enforce_privacy' option in .*package.yml, is invalid./,
+        result.error_value
+      )
+      assert_match(
+        /Private constants need to be prefixed with the top-level namespace operator `::`/,
+        result.error_value
+      )
+    end
+
+    private
+
     sig { returns(Packwerk::ApplicationValidator) }
     def validator
       @validator ||= Packwerk::ApplicationValidator.new

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -86,13 +86,13 @@ module Packwerk
 
     test 'check_package_manifests_for_privacy returns an error for constants without `::` prefix' do
       use_template(:minimal)
-      merge_into_app_yaml_file('package.yml', { 'enforce_privacy' => ['::PrivateThing', 'OtherThing'] })
+      merge_into_app_yaml_file('package.yml', { 'private_constants' => ['::PrivateThing', 'OtherThing'] })
 
       result = Packwerk::Privacy::Validator.new.call(package_set, config)
 
       refute result.ok?, result.error_value
       assert_match(
-        /'OtherThing', listed in the 'enforce_privacy' option in .*package.yml, is invalid./,
+        /'OtherThing', listed in the 'private_constants' option in .*package.yml, is invalid./,
         result.error_value
       )
       assert_match(


### PR DESCRIPTION
In #5 we removed support for providing a list of constants to the `enforce_privacy` setting in a `package.yml` file, meaning that only `true`, `false`, and `'strict'` were valid values. However, this change removed support for a feature that some were reliant on in Packwerk 2.2.2.

This PR reintroduces that feature by creating a new setting called `private_constants`. This is logically equivalent to the old list that could live on `enforce_privacy` before but in its own dedicated setting. If `enforce_privacy` is `false` or `nil`, this list is ignored. If this is not present then it is assumed that we want to enforce privacy on all constants outside the public directory for the package.