### PR TITLE
Allow layer configuration to take precedence

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.1.3)
+    packwerk-extensions (0.1.4)
       packwerk (>= 2.2.1)
       railties (>= 6.0.0)
       sorbet-runtime

--- a/lib/packwerk/architecture/package.rb
+++ b/lib/packwerk/architecture/package.rb
@@ -36,10 +36,12 @@ module Packwerk
 
           # This allows the layer to be inferred based on the package root
           package_root = package.name.split('/').first
-          if package_root && layers.names.include?(package_root)
+          if config['layer']
+            layer = config['layer']
+          elsif package_root && layers.names.include?(package_root)
             layer = package_root
           else
-            layer = config['layer']
+            layer = nil
           end
 
           Package.new(

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.1.3'
+  spec.version       = '0.1.4'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/unit/architecture/checker_test.rb
+++ b/test/unit/architecture/checker_test.rb
@@ -68,7 +68,23 @@ module Packwerk
           destination_package: orchestrator_pack
         )
 
+        assert_equal Package.from(orchestrator_pack, Layers.new).layer, 'orchestrator'
+        assert_equal Package.from(utility_pack, Layers.new).layer, 'utility'
         assert checker.invalid_reference?(reference)
+      end
+
+      test 'allows layer setting to override root directory location' do
+        orchestrator_pack = Packwerk::Package.new(name: 'orchestrator/some_pack', config: { 'layer' => 'specification', 'enforce_architecture' => true })
+        utility_pack = Packwerk::Package.new(name: 'utility/some_other_pack', config: { 'enforce_architecture' => true })
+        checker = architecture_checker
+        reference = build_reference(
+          source_package: utility_pack,
+          destination_package: orchestrator_pack
+        )
+
+        assert_equal Package.from(orchestrator_pack, Layers.new).layer, 'specification'
+        assert_equal Package.from(utility_pack, Layers.new).layer, 'utility'
+        refute checker.invalid_reference?(reference)
       end
 
       test 'is not an invalid reference if destination pack is below source package' do


### PR DESCRIPTION
This change allows a user to adopt this checker incrementally by adding a `layer` config if one of their layers is named the same as the existing location of their packs (e.g. they have a layer called `packs`)
