### PR TITLE
Fix example configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Currently, it ships the following checkers to help improve the boundaries betwee
 To register all checkers included in this gem, add the following to your `packwerk.yml`:
 
 ```yaml
-require: packwerk-extensions
+require:
+  - packwerk-extensions
 ```
 
 Alternatively, you can require individual checkers:


### PR DESCRIPTION
The current example configuration causes the following error
> undefined method `each' for "packwerk-extensions":String (NoMethodError)`

in https://github.com/Shopify/packwerk/blob/5eeecf7b0e65610928f71a4dca17f0d502033c80/lib/packwerk/configuration.rb#L85-L89

This patch fixes this.