### PR TITLE
Use ActiveSupport::Inflector in Privacy Validator's ConstantResolver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.1.4)
+    packwerk-extensions (0.1.5)
       packwerk (>= 2.2.1)
       railties (>= 6.0.0)
       sorbet-runtime
@@ -124,6 +124,7 @@ GEM
       sorbet-static (= 0.5.10672)
     sorbet-runtime (0.5.10672)
     sorbet-static (0.5.10672-universal-darwin-20)
+    sorbet-static (0.5.10672-universal-darwin-22)
     sorbet-static (0.5.10672-x86_64-linux)
     sorbet-static-and-runtime (0.5.10672)
       sorbet (= 0.5.10672)
@@ -158,6 +159,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/packwerk/privacy/validator.rb
+++ b/lib/packwerk/privacy/validator.rb
@@ -42,7 +42,8 @@ module Packwerk
         results = T.let([], T::Array[Result])
         resolver = ConstantResolver.new(
           root_path: configuration.root_path,
-          load_paths: configuration.load_paths
+          load_paths: configuration.load_paths,
+          inflector: ActiveSupport::Inflector
         )
 
         private_constants_setting.each do |config_file_path, setting|

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.1.4'
+  spec.version       = '0.1.5'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/fixtures/skeleton/components/timeline/app/models/graphql.rb
+++ b/test/fixtures/skeleton/components/timeline/app/models/graphql.rb
@@ -1,0 +1,2 @@
+module GraphQL
+end

--- a/test/fixtures/skeleton/components/timeline/app/models/graphql/private_thing.rb
+++ b/test/fixtures/skeleton/components/timeline/app/models/graphql/private_thing.rb
@@ -1,0 +1,4 @@
+module GraphQL
+  class PrivateThing
+  end
+end

--- a/test/fixtures/skeleton/components/timeline/package.yml
+++ b/test/fixtures/skeleton/components/timeline/package.yml
@@ -1,3 +1,4 @@
 enforce_privacy: true
 private_constants:
   - "::PrivateThing"
+  - "::GraphQL::PrivateThing"

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -3,6 +3,10 @@
 
 require 'rails'
 
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'GraphQL'
+end
+
 class Dummy < Rails::Application
   class << self
     def skeleton(*path)

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -39,6 +39,15 @@ module Packwerk
       assert result.ok?
     end
 
+    test 'check_all returns success when inflector defines acronym' do
+      use_template(:skeleton)
+
+      result = Packwerk::Privacy::Validator.new.call(package_set, config)
+
+      assert result.ok?
+      assert_nil result.error_value
+    end
+
     test 'check_all returns an error for invalid public_path value' do
       use_template(:minimal)
       merge_into_app_yaml_file('package.yml', { 'public_path' => [] })


### PR DESCRIPTION
### Problem

package.yml:
```yaml
private_constants:
  - "::ORM::Private"
```

config/initializers/inflections.rb:
```ruby
ActiveSupport::Inflector.inflections(:en) do |inflect|
  inflect.acronym "ORM"
end
```

```bash
✗ bin/packwerk validate

📦 Packwerk is running validation...

Validation failed ❗

---
'::ORM::Private', listed in /lib/orm/package.yml, could not be resolved.
This is probably because it is an autovivified namespace - a namespace module that doesn't have a
file explicitly defining it. Packwerk currently doesn't support declaring autovivified namespaces as
private. Add a orm/private.rb file to explicitly define the constant.

📦 Finished in 0.77 seconds
```

### Solution
`ConstantResolver` accepts any object that implements a `camelize` function. `ActiveSupport::Inflector` defines it and also understands defined acronyms

