### PR TITLE
Allow a package to gradually adopt privacy protection with ignored_private_constants

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.1.4)
+    packwerk-extensions (0.1.5)
       packwerk (>= 2.2.1)
       railties (>= 6.0.0)
       sorbet-runtime

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -32,6 +32,8 @@ module Packwerk
         privacy_option = privacy_package.enforce_privacy
         return false if enforcement_disabled?(privacy_option)
 
+        return false if privacy_package.ignored_private_constants.include?(reference.constant.name)
+
         explicitly_private_constant?(reference.constant, explicitly_private_constants: privacy_package.private_constants)
       end
 

--- a/lib/packwerk/privacy/package.rb
+++ b/lib/packwerk/privacy/package.rb
@@ -10,6 +10,7 @@ module Packwerk
       const :user_defined_public_path, T.nilable(String)
       const :enforce_privacy, T.nilable(T.any(T::Boolean, String))
       const :private_constants, T::Array[String]
+      const :ignored_private_constants, T::Array[String]
 
       sig { params(path: String).returns(T::Boolean) }
       def public_path?(path)
@@ -25,7 +26,8 @@ module Packwerk
             public_path: public_path_for(package),
             user_defined_public_path: user_defined_public_path(package),
             enforce_privacy: package.config['enforce_privacy'],
-            private_constants: package.config['private_constants'] || []
+            private_constants: package.config['private_constants'] || [],
+            ignored_private_constants: package.config['ignored_private_constants'] || []
           )
         end
 

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.1.4'
+  spec.version       = '0.1.5'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -48,6 +48,14 @@ module Packwerk
         assert checker.invalid_reference?(reference)
       end
 
+      test 'does not complain about private constant if it is an ignored_private_constant when using enforce_privacy' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'ignored_private_constants' => ['::SomeName'], 'enforce_privacy' => true })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package)
+
+        refute checker.invalid_reference?(reference)
+      end
+
       test 'complains about private constant if enforcing for specific constants' do
         destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeName'] })
         checker = privacy_checker


### PR DESCRIPTION
This is the same idea as https://github.com/Shopify/packwerk/pull/350, where we looked into adding `ignored_dependencies` to the dependency checker.

This allows a package to adopt the privacy protection, but specifically ignore certain constants.

The alternative to this is just moving a constant into public. However, this isn't ideal, as it suggests a constant is actually public, rather than just moved there to prevent privacy violations.

`ignored_private_constants` is a more explicit version of this.
