### PR TITLE
Allow a package to gradually activate strict mode with strict_privacy_ignored_patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ public_path: my/custom/path/
 ### Using specific private constants
 Sometimes it is desirable to only enforce privacy on a subset of constants in a package. You can do so by defining a `private_constants` list in your package.yml. Note that `enforce_privacy` must be set to `true` or `'strict'` for this to work.
 
+### Ignore strict mode for violation coming from specific path patterns
+If you want to activate `'strict'` mode on you package but have a few privacy violations you know you will deal with later,
+you can set a list of patterns to exclude.
+
+```yaml
+enforce_privacy: strict
+strict_privacy_ignored_patterns:
+- engines/another_engine/test/**/*
+```
+
+In this example, violations on constants of your engine referenced in those files `engines/another_engine/test/**/*` will not fail Packwerk checks.
+
 ### Package Privacy violation
 Packwerk thinks something is a privacy violation if you're referencing a constant, class, or module defined in the private implementation (i.e. not the public folder) of another package. We care about these because we want to make sure we only use parts of a package that have been exposed as public API.
 

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -44,6 +44,9 @@ module Packwerk
       end
       def strict_mode_violation?(listed_offense)
         publishing_package = listed_offense.reference.constant.package
+
+        return false if exclude_from_strict?(publishing_package.config['ignored_strict_privacy_for_paths'] || [], Pathname.new(listed_offense.reference.relative_path).cleanpath)
+
         publishing_package.config['enforce_privacy'] == 'strict'
       end
 
@@ -97,6 +100,13 @@ module Packwerk
         MESSAGE
 
         standard_message.chomp
+      end
+
+      sig { params(globs: T::Array[String], path: Pathname).returns(T::Boolean) }
+      def exclude_from_strict?(globs, path)
+        globs.any? do |glob|
+          path.fnmatch(glob, File::FNM_EXTGLOB)
+        end
       end
     end
   end

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -45,9 +45,13 @@ module Packwerk
       def strict_mode_violation?(listed_offense)
         publishing_package = listed_offense.reference.constant.package
 
-        return false if exclude_from_strict?(publishing_package.config['ignored_strict_privacy_for_paths'] || [], Pathname.new(listed_offense.reference.relative_path).cleanpath)
+        return false unless publishing_package.config['enforce_privacy'] == 'strict'
+        return false if exclude_from_strict?(
+          publishing_package.config['strict_privacy_ignored_patterns'] || [],
+          Pathname.new(listed_offense.reference.relative_path).cleanpath
+        )
 
-        publishing_package.config['enforce_privacy'] == 'strict'
+        true
       end
 
       sig do

--- a/lib/packwerk/privacy/package.rb
+++ b/lib/packwerk/privacy/package.rb
@@ -11,6 +11,7 @@ module Packwerk
       const :enforce_privacy, T.nilable(T.any(T::Boolean, String))
       const :private_constants, T::Array[String]
       const :ignored_private_constants, T::Array[String]
+      const :ignored_strict_privacy_for_paths, T::Array[String]
 
       sig { params(path: String).returns(T::Boolean) }
       def public_path?(path)
@@ -27,7 +28,8 @@ module Packwerk
             user_defined_public_path: user_defined_public_path(package),
             enforce_privacy: package.config['enforce_privacy'],
             private_constants: package.config['private_constants'] || [],
-            ignored_private_constants: package.config['ignored_private_constants'] || []
+            ignored_private_constants: package.config['ignored_private_constants'] || [],
+            ignored_strict_privacy_for_paths: package.config['ignored_strict_privacy_for_paths'] || []
           )
         end
 

--- a/lib/packwerk/privacy/package.rb
+++ b/lib/packwerk/privacy/package.rb
@@ -11,7 +11,7 @@ module Packwerk
       const :enforce_privacy, T.nilable(T.any(T::Boolean, String))
       const :private_constants, T::Array[String]
       const :ignored_private_constants, T::Array[String]
-      const :ignored_strict_privacy_for_paths, T::Array[String]
+      const :strict_privacy_ignored_patterns, T::Array[String]
 
       sig { params(path: String).returns(T::Boolean) }
       def public_path?(path)
@@ -29,7 +29,7 @@ module Packwerk
             enforce_privacy: package.config['enforce_privacy'],
             private_constants: package.config['private_constants'] || [],
             ignored_private_constants: package.config['ignored_private_constants'] || [],
-            ignored_strict_privacy_for_paths: package.config['ignored_strict_privacy_for_paths'] || []
+            strict_privacy_ignored_patterns: package.config['strict_privacy_ignored_patterns'] || []
           )
         end
 

--- a/lib/packwerk/privacy/validator.rb
+++ b/lib/packwerk/privacy/validator.rb
@@ -31,7 +31,7 @@ module Packwerk
 
       sig { override.returns(T::Array[String]) }
       def permitted_keys
-        %w[public_path enforce_privacy private_constants ignored_private_constants]
+        %w[public_path enforce_privacy private_constants ignored_private_constants ignored_strict_privacy_for_paths]
       end
 
       private

--- a/lib/packwerk/privacy/validator.rb
+++ b/lib/packwerk/privacy/validator.rb
@@ -31,7 +31,7 @@ module Packwerk
 
       sig { override.returns(T::Array[String]) }
       def permitted_keys
-        %w[public_path enforce_privacy private_constants ignored_private_constants ignored_strict_privacy_for_paths]
+        %w[public_path enforce_privacy private_constants ignored_private_constants strict_privacy_ignored_patterns]
       end
 
       private

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -88,6 +88,42 @@ module Packwerk
         refute checker.invalid_reference?(reference)
       end
 
+      test 'ignores strict mode if not enabled' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package, constant_location: 'destination_package/app/public/')
+        offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: 'privacy', message: '')
+
+        refute checker.strict_mode_violation?(offense)
+      end
+
+      test 'detect strict mode if enabled' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict' })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package, constant_location: 'destination_package/app/public/')
+        offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: 'privacy', message: '')
+
+        assert checker.strict_mode_violation?(offense)
+      end
+
+      test 'ignores strict mode if excluded path' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict', 'ignored_strict_privacy_for_paths' => ['some/**'] })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package, constant_location: 'destination_package/app/public/')
+        offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: 'privacy', message: '')
+
+        refute checker.strict_mode_violation?(offense)
+      end
+
+      test 'detects strict mode if not excluded path' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict', 'ignored_strict_privacy_for_paths' => ['test/**'] })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package, constant_location: 'destination_package/app/public/')
+        offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: 'privacy', message: '')
+
+        assert checker.strict_mode_violation?(offense)
+      end
+
       test 'only checks the package TODO file for private constants' do
         destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true, 'private_constants' => ['::SomeName'] })
         checker = privacy_checker

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -107,7 +107,7 @@ module Packwerk
       end
 
       test 'ignores strict mode if excluded path' do
-        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict', 'ignored_strict_privacy_for_paths' => ['some/**'] })
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict', 'strict_privacy_ignored_patterns' => ['some/**'] })
         checker = privacy_checker
         reference = build_reference(destination_package: destination_package, constant_location: 'destination_package/app/public/')
         offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: 'privacy', message: '')
@@ -116,7 +116,7 @@ module Packwerk
       end
 
       test 'detects strict mode if not excluded path' do
-        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict', 'ignored_strict_privacy_for_paths' => ['test/**'] })
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => 'strict', 'strict_privacy_ignored_patterns' => ['test/**'] })
         checker = privacy_checker
         reference = build_reference(destination_package: destination_package, constant_location: 'destination_package/app/public/')
         offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: 'privacy', message: '')


### PR DESCRIPTION
Building on the same pattern as https://github.com/rubyatscale/packwerk-extensions/pull/27, we would like to open the possibility to activate strict mode whilst being softer on specific paths.

At Doctolib we are in the process of pushing for isolated Engines but we would like to take care of violations coming from `test` files at a later time (In the meantime, we are still interested in tracking them)

This PRs introduce a `strict_privacy_ignored_patterns` property allowing to specify an array of path that will not trigger packwerk check.

For example, this configuration will continue to track test violations in the todo files, but will also trigger strict mode on all the other paths:

```
strict_privacy_ignored_patterns:
- test/**/*
- engines/test/**/*
```