### PR TITLE
Allow for sigil declaration for publicizing of constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ Example:
 public_path: my/custom/path/
 ```
 
+### Defining public constants through sigil
+You may make individual files public withhin a private package by usage of a comment within the `.rb` file containing `packwerk#publicize!`.
+
+Example:
+
+```ruby
+module Foo
+  class Update
+    # packwerk#publicize!
+  end
+end
+```
+Now `Foo::Update` is considered public even though the `foo` package might be set to `enforce_private: (true || :strict)`.
+
+It's important to note that when combining `packwerk#publicize!` with the declaration of `private_constants`,
+`packwerk validate` will raise an exception if both are used for the same constant. This must be resolved by removing
+the sigil from the `.rb` file or removing the constant from the list of `private_constants`.
+
 ### Using specific private constants
 Sometimes it is desirable to only enforce privacy on a subset of constants in a package. You can do so by defining a `private_constants` list in your package.yml. Note that `enforce_privacy` must be set to `true` or `'strict'` for this to work.
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ public_path: my/custom/path/
 ```
 
 ### Defining public constants through sigil
-You may make individual files public withhin a private package by usage of a comment within the first 5 lines of the `.rb` file containing `public_api: true`.
+You may make individual files public withhin a private package by usage of a comment within the first 5 lines of the `.rb` file containing `pack_public: true`.
 
 Example:
 
 ```ruby
-# public_api: true
+# pack_public: true
 module Foo
   class Update
   end
@@ -68,9 +68,40 @@ end
 ```
 Now `Foo::Update` is considered public even though the `foo` package might be set to `enforce_private: (true || :strict)`.
 
-It's important to note that when combining `puclic_api: true` with the declaration of `private_constants`,
+It's important to note that when combining `public_api: true` with the declaration of `private_constants`,
 `packwerk validate` will raise an exception if both are used for the same constant. This must be resolved by removing
 the sigil from the `.rb` file or removing the constant from the list of `private_constants`.
+
+If you are using rubocop, it may be configured in such a way that there must be an empty line after the magic keywords at the top of the file. Currently, this extension is not modifying rubocop in anyway so it does not recognize `public_pack: true` as a valid magic keyword option. That means placing it at the end of the magic keywords will throw a rubocop exception. However, you can place it first in the list to avoid an exception in rubocop.
+```
+-----
+# typed: ignore
+# frozen_string_literal: true
+# pack_public: true
+
+class Foo
+...
+end => Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments.
+
+------
+# typed: ignore
+# frozen_string_literal: true
+
+# pack_public: true
+
+class Foo
+...
+end => Less than ideal. This won't raise an issue in rubocop, however, only the first 5 lines are scanned for the magic comment of public_pack so there is risk at it being missed. It also is requiring extra empty lines in the group of magic comments.
+
+-----
+# pack_public: true
+# typed: ignore
+# frozen_string_literal: true
+
+class Foo
+...
+end => Ideal solution. No exceptions from rubocop and very low risk of the magic comment being out of range since
+```
 
 ### Using specific private constants
 Sometimes it is desirable to only enforce privacy on a subset of constants in a package. You can do so by defining a `private_constants` list in your package.yml. Note that `enforce_privacy` must be set to `true` or `'strict'` for this to work.

--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ public_path: my/custom/path/
 ```
 
 ### Defining public constants through sigil
-You may make individual files public withhin a private package by usage of a comment within the `.rb` file containing `packwerk#publicize!`.
+You may make individual files public withhin a private package by usage of a comment within the first 5 lines of the `.rb` file containing `public_api: true`.
 
 Example:
 
 ```ruby
+# public_api: true
 module Foo
   class Update
-    # packwerk#publicize!
   end
 end
 ```
 Now `Foo::Update` is considered public even though the `foo` package might be set to `enforce_private: (true || :strict)`.
 
-It's important to note that when combining `packwerk#publicize!` with the declaration of `private_constants`,
+It's important to note that when combining `puclic_api: true` with the declaration of `private_constants`,
 `packwerk validate` will raise an exception if both are used for the same constant. This must be resolved by removing
 the sigil from the `.rb` file or removing the constant from the list of `private_constants`.
 

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -12,16 +12,16 @@ module Packwerk
       include Packwerk::Checker
 
       VIOLATION_TYPE = T.let('privacy', String)
-      PUBLICIZED_SIGIL = T.let('public_api: true', String)
-      PUBLICIZED_SIGIL_REGEX = T.let(/#.*public_api:[ ]*true/, Regexp)
-      @@publicized_locations = T.let({}, T::Hash[String, T::Boolean])
+      PUBLICIZED_SIGIL = T.let('pack_public: true', String)
+      PUBLICIZED_SIGIL_REGEX = T.let(/#.*pack_public:\s*true/, Regexp)
+      @publicized_locations = T.let({}, T::Hash[String, T::Boolean])
 
       class << self
         extend T::Sig
 
         sig { returns(T::Hash[String, T::Boolean]) }
         def publicized_locations
-          @@publicized_locations
+          @publicized_locations
         end
 
         sig { params(location: String).returns(T::Boolean) }
@@ -40,7 +40,7 @@ module Packwerk
 
         sig { params(lines: T::Array[String]).returns(T::Boolean) }
         def content_contains_sigil?(lines)
-          lines[0..4].any? { |l| l =~ PUBLICIZED_SIGIL_REGEX }
+          T.must(lines[0..4]).any? { |l| l =~ PUBLICIZED_SIGIL_REGEX }
         end
       end
 

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -12,8 +12,8 @@ module Packwerk
       include Packwerk::Checker
 
       VIOLATION_TYPE = T.let('privacy', String)
-      PUBLICIZED_SIGIL = T.let('packwerk#publicize!', String)
-      PUBLICIZED_SIGIL_REGEX = T.let(/#.*#{PUBLICIZED_SIGIL}/, Regexp)
+      PUBLICIZED_SIGIL = T.let('public_api: true', String)
+      PUBLICIZED_SIGIL_REGEX = T.let(/#.*public_api:[ ]*true/, Regexp)
       @@publicized_locations = T.let({}, T::Hash[String, T::Boolean])
 
       class << self
@@ -40,7 +40,7 @@ module Packwerk
 
         sig { params(lines: T::Array[String]).returns(T::Boolean) }
         def content_contains_sigil?(lines)
-          lines.any? { |l| l =~ PUBLICIZED_SIGIL_REGEX }
+          lines[0..4].any? { |l| l =~ PUBLICIZED_SIGIL_REGEX }
         end
       end
 

--- a/lib/packwerk/privacy/validator.rb
+++ b/lib/packwerk/privacy/validator.rb
@@ -110,7 +110,7 @@ module Packwerk
       def check_private_constant_location(configuration, package_set, name, location, config_file_path)
         declared_package = package_set.package_from_path(relative_path(configuration, config_file_path))
         constant_package = package_set.package_from_path(location)
-        result = if constant_package == declared_package
+        if constant_package == declared_package
           check_for_publicized_constant(location, constant_package, name)
         else
           Result.new(
@@ -130,7 +130,7 @@ module Packwerk
             error_value: "'#{name}' is an explicitly publicized constant declared in #{location} through usage of " \
                          "'#{sigil}'. However, the package '#{constant_package}' is also declaring it as a private " \
                          "constant. This conflict must be resolved. Either remove '#{sigil}' from #{location} or " \
-                         "remove this constant from the list of private constants in the config for " \
+                         'remove this constant from the list of private constants in the config for ' \
                          "'#{constant_package}'."
           )
         else

--- a/lib/packwerk/privacy/validator.rb
+++ b/lib/packwerk/privacy/validator.rb
@@ -110,15 +110,31 @@ module Packwerk
       def check_private_constant_location(configuration, package_set, name, location, config_file_path)
         declared_package = package_set.package_from_path(relative_path(configuration, config_file_path))
         constant_package = package_set.package_from_path(location)
-
-        if constant_package == declared_package
-          Result.new(ok: true)
+        result = if constant_package == declared_package
+          check_for_publicized_constant(location, constant_package, name)
         else
           Result.new(
             ok: false,
             error_value: "'#{name}' is declared as private in the '#{declared_package}' package but appears to be " \
                          "defined\nin the '#{constant_package}' package. Packwerk resolved it to #{location}."
           )
+        end
+      end
+
+      sig { params(location: String, constant_package: Packwerk::Package, name: T.untyped).returns(Result) }
+      def check_for_publicized_constant(location, constant_package, name)
+        if Packwerk::Privacy::Checker.publicized_location?(location)
+          sigil = Packwerk::Privacy::Checker::PUBLICIZED_SIGIL
+          Result.new(
+            ok: false,
+            error_value: "'#{name}' is an explicitly publicized constant declared in #{location} through usage of " \
+                         "'#{sigil}'. However, the package '#{constant_package}' is also declaring it as a private " \
+                         "constant. This conflict must be resolved. Either remove '#{sigil}' from #{location} or " \
+                         "remove this constant from the list of private constants in the config for " \
+                         "'#{constant_package}'."
+          )
+        else
+          Result.new(ok: true)
         end
       end
 

--- a/test/fixtures/skeleton/components/sales/app/models/order/foo.rb
+++ b/test/fixtures/skeleton/components/sales/app/models/order/foo.rb
@@ -1,6 +1,6 @@
 # typed: ignore
 # frozen_string_literal: true
-# packwerk#publicize!
+# public_api: true
 
 class Order
   class Foo

--- a/test/fixtures/skeleton/components/sales/app/models/order/foo.rb
+++ b/test/fixtures/skeleton/components/sales/app/models/order/foo.rb
@@ -1,6 +1,6 @@
+# pack_public: true
 # typed: ignore
 # frozen_string_literal: true
-# public_api: true
 
 class Order
   class Foo

--- a/test/fixtures/skeleton/components/sales/app/models/order/foo.rb
+++ b/test/fixtures/skeleton/components/sales/app/models/order/foo.rb
@@ -1,0 +1,8 @@
+# typed: ignore
+# frozen_string_literal: true
+# packwerk#publicize!
+
+class Order
+  class Foo
+  end
+end

--- a/test/support/factory_helper.rb
+++ b/test/support/factory_helper.rb
@@ -16,6 +16,8 @@ module FactoryHelper
       destination_package
     )
 
+    Packwerk::Privacy::Checker.publicized_locations['some/location.rb'] = false
+
     Packwerk::Reference.new(
       package: source_package,
       relative_path: path,

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -48,6 +48,14 @@ module Packwerk
         assert checker.invalid_reference?(reference)
       end
 
+      test 'does not complain about private constant if enforcing privacy for everything and the destination is publicizing the file' do
+        destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'enforce_privacy' => true })
+        checker = privacy_checker
+        reference = build_reference(destination_package: destination_package)
+        Packwerk::Privacy::Checker.publicized_locations['some/location.rb'] = true
+        refute checker.invalid_reference?(reference)
+      end
+
       test 'does not complain about private constant if it is an ignored_private_constant when using enforce_privacy' do
         destination_package = Packwerk::Package.new(name: 'destination_package', config: { 'ignored_private_constants' => ['::SomeName'], 'enforce_privacy' => true })
         checker = privacy_checker

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -116,19 +116,19 @@ module Packwerk
 
       test 'content_contains_sigil?' do
         content_with_valid_sigils = [
-          ['line 1', 'line 2', 'line 3', 'line 4', '# public_api: true'],
-          ['#public_api:true', 'line 2', 'line 3'],
-          ['line 1', '#       public_api:         true']
+          ['line 1', 'line 2', 'line 3', 'line 4', '# pack_public: true'],
+          ['#pack_public:true', 'line 2', 'line 3'],
+          ['line 1', '#       pack_public:         true']
         ]
         content_with_invalid_or_missing_sigils = [
-          ['line 1', 'line 2', 'line 3', 'line 4', 'line 5', '# public_api: true'],
+          ['line 1', 'line 2', 'line 3', 'line 4', 'line 5', '# pack_public: true'],
           ['#pulic_api:', 'line 2', 'line 3'],
-          ['line 1', '#       public_api:         false'],
-          ['# public_api: false', 'line 2', 'line 3'],
+          ['line 1', '#       pack_public:         false'],
+          ['# pack_public: false', 'line 2', 'line 3'],
           ['line 1', 'EOF']
         ]
-        assert content_with_valid_sigils.all? { |content|  Privacy::Checker.content_contains_sigil?(content) }
-        assert content_with_invalid_or_missing_sigils.none? { |content|  Privacy::Checker.content_contains_sigil?(content) }
+        assert(content_with_valid_sigils.all? { |content| Privacy::Checker.content_contains_sigil?(content) })
+        assert(content_with_invalid_or_missing_sigils.none? { |content| Privacy::Checker.content_contains_sigil?(content) })
       end
 
       private

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -114,6 +114,23 @@ module Packwerk
         MSG
       end
 
+      test 'content_contains_sigil?' do
+        content_with_valid_sigils = [
+          ['line 1', 'line 2', 'line 3', 'line 4', '# public_api: true'],
+          ['#public_api:true', 'line 2', 'line 3'],
+          ['line 1', '#       public_api:         true']
+        ]
+        content_with_invalid_or_missing_sigils = [
+          ['line 1', 'line 2', 'line 3', 'line 4', 'line 5', '# public_api: true'],
+          ['#pulic_api:', 'line 2', 'line 3'],
+          ['line 1', '#       public_api:         false'],
+          ['# public_api: false', 'line 2', 'line 3'],
+          ['line 1', 'EOF']
+        ]
+        assert content_with_valid_sigils.all? { |content|  Privacy::Checker.content_contains_sigil?(content) }
+        assert content_with_invalid_or_missing_sigils.none? { |content|  Privacy::Checker.content_contains_sigil?(content) }
+      end
+
       private
 
       sig { returns(Checker) }

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -40,7 +40,7 @@ module Packwerk
         assert result.ok?
       end
 
-      test 'check_all returns an error when a privatized constant is declared and the constant is also declaring public_api: true' do
+      test 'check_all returns an error when a privatized constant is declared and the constant is also declaring pack_public: true' do
         use_template(:skeleton)
         merge_into_app_yaml_file('/components/sales/package.yml', { 'private_constants' => ['::Order::Foo'] })
         result = Packwerk::Privacy::Validator.new.call(package_set, config)

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -40,6 +40,14 @@ module Packwerk
         assert result.ok?
       end
 
+      test 'check_all returns an error when a privatized constant is declared and the constant is also declaring packwerk#publicize!' do
+        use_template(:skeleton)
+        merge_into_app_yaml_file('/components/sales/package.yml', { 'private_constants' => ['::Order::Foo'] })
+        result = Packwerk::Privacy::Validator.new.call(package_set, config)
+        refute result.ok?
+        assert_match(/is an explicitly publicized constant declared in/, result.error_value)
+      end
+
       test 'check_all returns success when inflector defines acronym' do
         use_template(:skeleton)
 

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -40,7 +40,7 @@ module Packwerk
         assert result.ok?
       end
 
-      test 'check_all returns an error when a privatized constant is declared and the constant is also declaring packwerk#publicize!' do
+      test 'check_all returns an error when a privatized constant is declared and the constant is also declaring public_api: true' do
         use_template(:skeleton)
         merge_into_app_yaml_file('/components/sales/package.yml', { 'private_constants' => ['::Order::Foo'] })
         result = Packwerk::Privacy::Validator.new.call(package_set, config)


### PR DESCRIPTION
* Allows for declaring of a constant to be public through a comment in the file of `packwerk#publicize!`
* The lookup is cached at the class level inside of `Packwerk::Privacy::Checker` to avoid duplicative file scans.
* Adds logic to validator to ensure there isn't conflict between files explicitly declared as private in `package.yml` and explicitly declared as public by usage of the sigil.
* Test coverage added.