### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ It's important to note that when combining `public_api: true` with the declarati
 `packwerk validate` will raise an exception if both are used for the same constant. This must be resolved by removing
 the sigil from the `.rb` file or removing the constant from the list of `private_constants`.
 
-If you are using rubocop, it may be configured in such a way that there must be an empty line after the magic keywords at the top of the file. Currently, this extension is not modifying rubocop in any way so it does not recognize `public_pack: true` as a valid magic keyword option. That means placing it at the end of the magic keywords will throw a rubocop exception. However, you can place it first in the list to avoid an exception in rubocop.
+If you are using rubocop, it may be configured in such a way that there must be an empty line after the magic keywords at the top of the file. Currently, this extension is not modifying rubocop in any way so it does not recognize `pack_public: true` as a valid magic keyword option. That means placing it at the end of the magic keywords will throw a rubocop exception. However, you can place it first in the list to avoid an exception in rubocop.
 ```
 -----
 # typed: ignore
@@ -109,7 +109,7 @@ end => Layout/EmptyLineAfterMagicComment: Add an empty line after magic comments
 
 class Foo
 ...
-end => Less than ideal. This won't raise an issue in rubocop, however, only the first 5 lines are scanned for the magic comment of public_pack so there is risk at it being missed. It also is requiring extra empty lines in the group of magic comments.
+end => Less than ideal. This won't raise an issue in rubocop, however, only the first 5 lines are scanned for the magic comment of pack_public so there is risk at it being missed. It also is requiring extra empty lines in the group of magic comments.
 
 -----
 # pack_public: true


### PR DESCRIPTION
I noticed an unconsistency, both `pack_public` and `public_pack` being used in the README.