### PR TITLE
Layer validations should not depend on package dependencies

### DIFF
--- a/lib/packwerk/architecture/validator.rb
+++ b/lib/packwerk/architecture/validator.rb
@@ -27,8 +27,6 @@ module Packwerk
           result = check_layer_setting(package, f)
           results << result
           next if !result.ok?
-
-          results += check_dependencies_setting(package_set, package, f)
         end
 
         merge_results(results, separator: "\n---\n")
@@ -42,27 +40,6 @@ module Packwerk
       sig { override.returns(T::Array[String]) }
       def permitted_keys
         %w[enforce_architecture layer]
-      end
-
-      sig do
-        params(package_set: PackageSet, package: Package, config_file_path: String).returns(T::Array[Result])
-      end
-      def check_dependencies_setting(package_set, package, config_file_path)
-        results = T.let([], T::Array[Result])
-        package.config.fetch('dependencies', []).each do |dependency|
-          other_packwerk_package = package_set.fetch(dependency)
-          next if other_packwerk_package.nil?
-
-          other_package = Package.from(other_packwerk_package, layers)
-          next if package.can_depend_on?(other_package, layers: layers)
-
-          results << Result.new(
-            ok: false,
-            error_value: "Invalid 'dependencies' in #{config_file_path.inspect}. '#{config_file_path}' has a layer type of '#{package.layer},' which cannot rely on '#{other_packwerk_package.name},' which has a layer type of '#{other_package.layer}.' `architecture_layers` can be found in packwerk.yml."
-          )
-        end
-
-        results
       end
 
       sig do

--- a/test/unit/architecture/validator_test.rb
+++ b/test/unit/architecture/validator_test.rb
@@ -106,15 +106,6 @@ module Packwerk
         assert result.ok?
       end
 
-      test 'call returns an error if a dependency violates architecture layers' do
-        merge_into_app_yaml_file('packs/my_utility/package.yml', { 'dependencies' => ['packs/my_pack'], 'enforce_architecture' => true, 'layer' => 'utility' })
-        merge_into_app_yaml_file('packs/my_pack/package.yml', { 'enforce_architecture' => false, 'layer' => 'package' })
-
-        result = validator.call(package_set, config)
-
-        assert_match(%r{Invalid 'dependencies' in.*?packs/my_utility/package.yml"..*?packs/my_utility/package.yml' has a layer type of 'utility,' which cannot rely on 'packs/my_pack,' which has a layer type of 'package.' `architecture_layers` can be found in packwerk.yml.}, result.error_value)
-      end
-
       sig { returns(Packwerk::Architecture::Validator) }
       def validator
         @validator ||= Packwerk::Architecture::Validator.new


### PR DESCRIPTION
## Background
Before this PR, architecture layer validations considered package.yml `dependencies` as possible violations.

We decided against this approach for the following reasons:

1. Maintaining separation between dependency definitions and architectural layer validations is beneficial. This separation allows teams to selectively apply different types of validations without worrying about interdependencies between them.

2. If layer validation takes into account declared dependencies, the following scenario will come up:
i) A `package.yml` specifies a legitimate dependency
ii) Subsequently, a new layer validation is introduced involving the aforementioned valid dependency
iii) If layer validation flags the dependency as invalid, the dependency will need to be removed and both layer and dependency violations will be added to the associated `package_todo.yml`

3. Actual layer violations are already caught by `check`.

## Change
- removed the layer validation based off of package.yml dependencies