### PR TITLE
Renaming `architecture` to `layer`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.1.11)
+    packwerk-extensions (0.2.0)
       packwerk (>= 2.2.1)
       railties (>= 6.0.0)
       sorbet-runtime

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently, it ships the following checkers to help improve the boundaries betwee
 - A `privacy` checker that ensures other packages are using your package's public API
 - A `visibility` checker that allows packages to be private except to an explicit group of other packages.
 - A `folder_visibility` checker that allows packages to their sibling packs and parent pack (to be used in an application that uses folder packs)
-- An `architecture` checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
+- An `layer` checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
 
 ## Installation
 
@@ -26,7 +26,7 @@ require:
   - packwerk/privacy/checker
   - packwerk/visibility/checker
   - packwerk/folder_visibility/checker
-  - packwerk/architecture/checker
+  - packwerk/layer/checker
 ```
 
 ## Privacy Checker
@@ -194,12 +194,12 @@ packs/b/packs/h           OK (sibling)
 packs/c                   VIOLATION
 ```
 
-## Architecture Checker
-The architecture checker can be used to enforce constraints on what can depend on what.
+## Layer Checker
+The layer checker can be used to enforce constraints on what can depend on what.
 
-To enforce architecture for your package, first define the `architecture_layers` in `packwerk.yml`, for example:
+To enforce layers for your package, first define the `layers` in `packwerk.yml`, for example:
 ```
-architecture_layers:
+layers:
   - package
   - utility
 ```
@@ -207,7 +207,7 @@ architecture_layers:
 Then, turn on the checker in your package:
 ```yaml
 # components/merchandising/package.yml
-enforce_architecture: true
+enforce_layers: true
 layer: utility
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently, it ships the following checkers to help improve the boundaries betwee
 - A `privacy` checker that ensures other packages are using your package's public API
 - A `visibility` checker that allows packages to be private except to an explicit group of other packages.
 - A `folder_visibility` checker that allows packages to their sibling packs and parent pack (to be used in an application that uses folder packs)
-- An `layer` (formerly `architecture`) checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
+- A `layer` (formerly `architecture`) checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
 
 ## Installation
 
@@ -219,6 +219,19 @@ The "Layer Checker" was formerly named "Architecture Checker". The associated ke
 - package.yml `enforce_architecture`, which is now `enforce_layers`
 - package.yml `layer` is still a valid key
 - package_todo.yml - `architecture`, which is now `layer`
+
+```bash
+  # script to migrate code from deprecated "architecture" violations to "layer" violations
+
+  # replace 'architecture_layers' with 'layers' in packwerk.yml
+  sed -i '' 's/architecture_layers/layers/g' ./packwerk.yml
+  
+  # replace 'enforce_architecture' with 'enforce_layers' in package.yml files
+  `rg -l 'enforce_architecture' -g 'package.yml' | xargs sed -i '' 's,enforce_architecture,enforce_layers,g'`
+
+  # replace '- architecture' with '- layer' in package_todo.yml files
+  `rg -l 'architecture' -g 'package_todo.yml' | xargs sed -i '' 's/- architecture/- layer/g'`
+```
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently, it ships the following checkers to help improve the boundaries betwee
 - A `privacy` checker that ensures other packages are using your package's public API
 - A `visibility` checker that allows packages to be private except to an explicit group of other packages.
 - A `folder_visibility` checker that allows packages to their sibling packs and parent pack (to be used in an application that uses folder packs)
-- An `layer` checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
+- An `layer` (formerly `architecture`) checker that allows packages to specify their "layer" and requires that each layer only communicate with layers below it.
 
 ## Installation
 
@@ -212,6 +212,13 @@ layer: utility
 ```
 
 Now this pack can only depend on other utility packages.
+
+### Deprecated Architecture Checker
+The "Layer Checker" was formerly named "Architecture Checker". The associated keys were:
+- packwerk.yml `architecture_layers`, which is now `layers`
+- package.yml `enforce_architecture`, which is now `enforce_layers`
+- package.yml `layer` is still a valid key
+- package_todo.yml - `architecture`, which is now `layer`
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The "Layer Checker" was formerly named "Architecture Checker". The associated ke
 
 ```bash
   # script to migrate code from deprecated "architecture" violations to "layer" violations
+  # sed and ripgrep required
 
   # replace 'architecture_layers' with 'layers' in packwerk.yml
   sed -i '' 's/architecture_layers/layers/g' ./packwerk.yml

--- a/lib/packwerk-extensions.rb
+++ b/lib/packwerk-extensions.rb
@@ -7,7 +7,7 @@ require 'packwerk'
 require 'packwerk/privacy/checker'
 require 'packwerk/visibility/checker'
 require 'packwerk/folder_visibility/checker'
-require 'packwerk/architecture/checker'
+require 'packwerk/layer/checker'
 
 module Packwerk
   module Extensions

--- a/lib/packwerk/layer/checker.rb
+++ b/lib/packwerk/layer/checker.rb
@@ -38,7 +38,7 @@ module Packwerk
 
       sig { override.returns(String) }
       def violation_type
-        @violation_type ||= Config.new.violation_key
+        @violation_type ||= layer_config.violation_key
       end
 
       sig do
@@ -59,7 +59,7 @@ module Packwerk
       end
       def strict_mode_violation?(listed_offense)
         constant_package = listed_offense.reference.package
-        constant_package.config['enforce_layers'] == 'strict'
+        constant_package.config[layer_config.enforce_key] == 'strict'
       end
 
       sig do
@@ -97,6 +97,11 @@ module Packwerk
       sig { returns(Layers) }
       def layers
         @layers ||= T.let(Layers.new, T.nilable(Packwerk::Layer::Layers))
+      end
+
+      sig { returns(Config) }
+      def layer_config
+        @layer_config ||= T.let(Config.new, T.nilable(Config))
       end
     end
   end

--- a/lib/packwerk/layer/checker.rb
+++ b/lib/packwerk/layer/checker.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'packwerk/layer/config'
 require 'packwerk/layer/layers'
 require 'packwerk/layer/package'
 require 'packwerk/layer/validator'
@@ -30,11 +31,14 @@ module Packwerk
       extend T::Sig
       include Packwerk::Checker
 
-      VIOLATION_TYPE = T.let('layer', String)
+      sig { void }
+      def initialize
+        @violation_type = T.let(@violation_type, T.nilable(String))
+      end
 
       sig { override.returns(String) }
       def violation_type
-        VIOLATION_TYPE
+        @violation_type ||= Config.new.violation_key
       end
 
       sig do
@@ -68,8 +72,8 @@ module Packwerk
         referencing_package = Package.from(reference.package, layers)
 
         message = <<~MESSAGE
-          Layer violation: '#{reference.constant.name}' belongs to '#{reference.constant.package}', whose layer type is "#{constant_package.layer}."
-          This constant cannot be referenced by '#{reference.package}', whose layer type is "#{referencing_package.layer}."
+          Layer violation: '#{reference.constant.name}' belongs to '#{reference.constant.package}', whose layer type is "#{constant_package.layer}".
+          This constant cannot be referenced by '#{reference.package}', whose layer type is "#{referencing_package.layer}".
           Packs in a lower layer may not access packs in a higher layer. See the `layers` in packwerk.yml. Current hierarchy:
           - #{layers.names_list.join("\n- ")}
 

--- a/lib/packwerk/layer/checker.rb
+++ b/lib/packwerk/layer/checker.rb
@@ -1,16 +1,16 @@
 # typed: strict
 # frozen_string_literal: true
 
-require 'packwerk/architecture/layers'
-require 'packwerk/architecture/package'
-require 'packwerk/architecture/validator'
+require 'packwerk/layer/layers'
+require 'packwerk/layer/package'
+require 'packwerk/layer/validator'
 
 module Packwerk
-  module Architecture
+  module Layer
     # This enforces "layered architecture," which allows each class to be designated as one of N layers
     # configured by the client in `packwerk.yml`, for example:
     #
-    # architecture_layers:
+    # layers:
     #   - orchestrator
     #   - business_domain
     #   - platform
@@ -18,7 +18,7 @@ module Packwerk
     #   - specification
     #
     # Then a package can configure:
-    # enforce_architecture: true | false | strict
+    # enforce_layers: true | false | strict
     # layer: utility
     #
     # This is intended to provide:
@@ -30,7 +30,7 @@ module Packwerk
       extend T::Sig
       include Packwerk::Checker
 
-      VIOLATION_TYPE = T.let('architecture', String)
+      VIOLATION_TYPE = T.let('layer', String)
 
       sig { override.returns(String) }
       def violation_type
@@ -55,7 +55,7 @@ module Packwerk
       end
       def strict_mode_violation?(listed_offense)
         constant_package = listed_offense.reference.package
-        constant_package.config['enforce_architecture'] == 'strict'
+        constant_package.config['enforce_layers'] == 'strict'
       end
 
       sig do
@@ -68,9 +68,9 @@ module Packwerk
         referencing_package = Package.from(reference.package, layers)
 
         message = <<~MESSAGE
-          Architecture layer violation: '#{reference.constant.name}' belongs to '#{reference.constant.package}', whose architecture layer type is "#{constant_package.layer}."
-          This constant cannot be referenced by '#{reference.package}', whose architecture layer type is "#{referencing_package.layer}."
-          Packs in a lower layer may not access packs in a higher layer. See the `architecture_layers` in packwerk.yml. Current hierarchy:
+          Layer violation: '#{reference.constant.name}' belongs to '#{reference.constant.package}', whose layer type is "#{constant_package.layer}."
+          This constant cannot be referenced by '#{reference.package}', whose layer type is "#{referencing_package.layer}."
+          Packs in a lower layer may not access packs in a higher layer. See the `layers` in packwerk.yml. Current hierarchy:
           - #{layers.names_list.join("\n- ")}
 
           #{standard_help_message(reference)}
@@ -92,7 +92,7 @@ module Packwerk
 
       sig { returns(Layers) }
       def layers
-        @layers ||= T.let(Layers.new, T.nilable(Packwerk::Architecture::Layers))
+        @layers ||= T.let(Layers.new, T.nilable(Packwerk::Layer::Layers))
       end
     end
   end

--- a/lib/packwerk/layer/config.rb
+++ b/lib/packwerk/layer/config.rb
@@ -1,0 +1,46 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  module Layer
+    class Config
+      extend T::Sig
+
+      ARCHITECTURE_VIOLATION_TYPE = T.let('architecture', String)
+      ARCHITECTURE_ENFORCE = T.let('enforce_architecture', String)
+      LAYER_VIOLATION_TYPE = T.let('layer', String)
+      LAYER_ENFORCE = T.let('enforce_layers', String)
+
+      sig { void }
+      def initialize
+        @layers_key_configured = T.let(@layers_key_configured, T.nilable(T::Boolean))
+        @layers_list = T.let(@layers_list, T.nilable(T::Array[String]))
+      end
+
+      sig { returns(T::Array[String]) }
+      def layers_list
+        @layers_list ||= YAML.load_file('packwerk.yml')[layers_key] || []
+      end
+
+      sig { returns(T::Boolean) }
+      def layers_key_configured?
+        @layers_key_configured ||= YAML.load_file('packwerk.yml')['architecture_layers'].nil?
+      end
+
+      sig { returns(String) }
+      def layers_key
+        layers_key_configured? ? 'layers' : 'architecture_layers'
+      end
+
+      sig { returns(String) }
+      def violation_key
+        layers_key_configured? ? LAYER_VIOLATION_TYPE : ARCHITECTURE_VIOLATION_TYPE
+      end
+
+      sig { returns(String) }
+      def enforce_key
+        layers_key_configured? ? LAYER_ENFORCE : ARCHITECTURE_ENFORCE
+      end
+    end
+  end
+end

--- a/lib/packwerk/layer/layers.rb
+++ b/lib/packwerk/layer/layers.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module Packwerk
-  module Architecture
+  module Layer
     class Layers
       extend T::Sig
 
@@ -29,7 +29,7 @@ module Packwerk
 
       sig { returns(T::Array[String]) }
       def names_list
-        @names_list ||= YAML.load_file('packwerk.yml')['architecture_layers'] || []
+        @names_list ||= YAML.load_file('packwerk.yml')['layers'] || []
       end
     end
   end

--- a/lib/packwerk/layer/layers.rb
+++ b/lib/packwerk/layer/layers.rb
@@ -29,7 +29,7 @@ module Packwerk
 
       sig { returns(T::Array[String]) }
       def names_list
-        @names_list ||= YAML.load_file('packwerk.yml')['layers'] || []
+        @names_list ||= Config.new.layers_list
       end
     end
   end

--- a/lib/packwerk/layer/package.rb
+++ b/lib/packwerk/layer/package.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module Packwerk
-  module Architecture
+  module Layer
     class Package < T::Struct
       extend T::Sig
 
@@ -46,7 +46,7 @@ module Packwerk
 
           Package.new(
             layer: layer,
-            enforcement_setting: config['enforce_architecture'],
+            enforcement_setting: config['enforce_layers'],
             config: config
           )
         end

--- a/lib/packwerk/layer/package.rb
+++ b/lib/packwerk/layer/package.rb
@@ -46,7 +46,7 @@ module Packwerk
 
           Package.new(
             layer: layer,
-            enforcement_setting: config['enforce_layers'],
+            enforcement_setting: config[Config.new.enforce_key],
             config: config
           )
         end

--- a/lib/packwerk/layer/validator.rb
+++ b/lib/packwerk/layer/validator.rb
@@ -16,13 +16,17 @@ module Packwerk
         package_set.each do |package|
           config = package.config
           f = Pathname.new(package.name).join('package.yml').to_s
+          package = Package.from(package, layers)
+
           next if !config
 
-          result = check_enforce_layers_setting(f, config['enforce_layers'])
+          result = check_enforce_key(package, f, config)
           results << result
           next if !result.ok?
 
-          package = Package.from(package, layers)
+          result = check_enforce_layers_setting(f, config[layer_config.enforce_key])
+          results << result
+          next if !result.ok?
 
           result = check_layer_setting(package, f)
           results << result
@@ -37,9 +41,36 @@ module Packwerk
         @layers ||= T.let(Layers.new, T.nilable(Packwerk::Layer::Layers))
       end
 
+      sig { returns(Config) }
+      def layer_config
+        @layer_config ||= T.let(Config.new, T.nilable(Config))
+      end
+
       sig { override.returns(T::Array[String]) }
       def permitted_keys
-        %w[enforce_layers layer]
+        [layer_config.enforce_key, 'layer']
+      end
+
+      sig do
+        params(package: Package, config_file_path: String, config: T::Hash[T.untyped, T.untyped]).returns(Result)
+      end
+      def check_enforce_key(package, config_file_path, config)
+        enforce_layer_present = !config[Config::LAYER_ENFORCE].nil?
+        enforce_architecture_present = !config[Config::ARCHITECTURE_ENFORCE].nil?
+
+        if layer_config.enforce_key == Config::LAYER_ENFORCE && enforce_architecture_present
+          Result.new(
+            ok: false,
+            error_value: "Unexpected `enforce_architecture` option in #{config_file_path.inspect}. Did you mean `enforce_layers`?"
+          )
+        elsif layer_config.enforce_key == Config::ARCHITECTURE_ENFORCE && enforce_layer_present
+          Result.new(
+            ok: false,
+            error_value: "Unexpected `enforce_layers` option in #{config_file_path.inspect}. Did you mean `enforce_architecture`?"
+          )
+        else
+          Result.new(ok: true)
+        end
       end
 
       sig do
@@ -52,7 +83,7 @@ module Packwerk
         if layer.nil? && package.enforces?
           Result.new(
             ok: false,
-            error_value: "Invalid 'layer' option in #{config_file_path.inspect}: #{package.layer.inspect}. `layer` must be set if `enforce_layers` is on."
+            error_value: "Invalid 'layer' option in #{config_file_path.inspect}: #{package.layer.inspect}. `layer` must be set if `#{layer_config.enforce_key}` is on."
           )
         elsif valid_layer
           Result.new(ok: true)
@@ -74,12 +105,12 @@ module Packwerk
         if !valid_value
           Result.new(
             ok: false,
-            error_value: "Invalid 'enforce_layers' option in #{config_file_path.inspect}: #{setting.inspect}"
+            error_value: "Invalid '#{layer_config.enforce_key}' option in #{config_file_path.inspect}: #{setting.inspect}"
           )
         elsif activated_value && !layers_set
           Result.new(
             ok: false,
-            error_value: "Cannot set 'enforce_layers' option in #{config_file_path.inspect} until `layers` have been specified in `packwerk.yml`"
+            error_value: "Cannot set '#{layer_config.enforce_key}' option in #{config_file_path.inspect} until `layers` have been specified in `packwerk.yml`"
           )
         else
           Result.new(ok: true)

--- a/lib/packwerk/layer/validator.rb
+++ b/lib/packwerk/layer/validator.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module Packwerk
-  module Architecture
+  module Layer
     class Validator
       extend T::Sig
       include Packwerk::Validator
@@ -18,7 +18,7 @@ module Packwerk
           f = Pathname.new(package.name).join('package.yml').to_s
           next if !config
 
-          result = check_enforce_architecture_setting(f, config['enforce_architecture'])
+          result = check_enforce_layers_setting(f, config['enforce_layers'])
           results << result
           next if !result.ok?
 
@@ -34,12 +34,12 @@ module Packwerk
 
       sig { returns(Layers) }
       def layers
-        @layers ||= T.let(Layers.new, T.nilable(Packwerk::Architecture::Layers))
+        @layers ||= T.let(Layers.new, T.nilable(Packwerk::Layer::Layers))
       end
 
       sig { override.returns(T::Array[String]) }
       def permitted_keys
-        %w[enforce_architecture layer]
+        %w[enforce_layers layer]
       end
 
       sig do
@@ -52,7 +52,7 @@ module Packwerk
         if layer.nil? && package.enforces?
           Result.new(
             ok: false,
-            error_value: "Invalid 'layer' option in #{config_file_path.inspect}: #{package.layer.inspect}. `layer` must be set if `enforce_architecture` is on."
+            error_value: "Invalid 'layer' option in #{config_file_path.inspect}: #{package.layer.inspect}. `layer` must be set if `enforce_layers` is on."
           )
         elsif valid_layer
           Result.new(ok: true)
@@ -67,19 +67,19 @@ module Packwerk
       sig do
         params(config_file_path: String, setting: T.untyped).returns(Result)
       end
-      def check_enforce_architecture_setting(config_file_path, setting)
+      def check_enforce_layers_setting(config_file_path, setting)
         activated_value = [true, 'strict'].include?(setting)
         valid_value = [true, nil, false, 'strict'].include?(setting)
         layers_set = layers.names.any?
         if !valid_value
           Result.new(
             ok: false,
-            error_value: "Invalid 'enforce_architecture' option in #{config_file_path.inspect}: #{setting.inspect}"
+            error_value: "Invalid 'enforce_layers' option in #{config_file_path.inspect}: #{setting.inspect}"
           )
         elsif activated_value && !layers_set
           Result.new(
             ok: false,
-            error_value: "Cannot set 'enforce_architecture' option in #{config_file_path.inspect} until `architectural_layers` have been specified in `packwerk.yml`"
+            error_value: "Cannot set 'enforce_layers' option in #{config_file_path.inspect} until `layers` have been specified in `packwerk.yml`"
           )
         else
           Result.new(ok: true)

--- a/lib/packwerk/visibility/validator.rb
+++ b/lib/packwerk/visibility/validator.rb
@@ -14,7 +14,7 @@ module Packwerk
         visible_settings = package_manifests_settings_for(configuration, 'visible_to')
         results = T.let([], T::Array[Result])
 
-        all_package_names = package_set.map(&:name).to_set
+        all_package_names = package_set.to_set(&:name)
 
         package_manifests_settings_for(configuration, 'enforce_visibility').each do |config, setting|
           next if setting.nil?

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
           'public gem pushes.'
   end
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['README.md', 'lib/**/*']
 

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.1.11'
+  spec.version       = '0.2.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 

--- a/test/unit/layer/checker_architecture_test.rb
+++ b/test/unit/layer/checker_architecture_test.rb
@@ -12,7 +12,7 @@ module Packwerk
 
       def write_config
         write_app_file('packwerk.yml', <<~YML)
-          layers:
+          architecture_layers:
             - orchestrator
             - business_domain
             - platform
@@ -37,10 +37,6 @@ module Packwerk
 
       teardown do
         teardown_application_fixture
-      end
-
-      test 'determines violation type' do
-        assert_equal layer_checker.violation_type, 'layer'
       end
 
       test 'ignores if origin package is not enforcing' do

--- a/test/unit/layer/checker_test.rb
+++ b/test/unit/layer/checker_test.rb
@@ -4,7 +4,7 @@
 require 'test_helper'
 
 module Packwerk
-  module Architecture
+  module Layer
     class CheckerTest < Minitest::Test
       extend T::Sig
       include FactoryHelper
@@ -12,7 +12,7 @@ module Packwerk
 
       def write_config
         write_app_file('packwerk.yml', <<~YML)
-          architecture_layers:
+          layers:
             - orchestrator
             - business_domain
             - platform
@@ -22,11 +22,11 @@ module Packwerk
       end
 
       def orchestrator_pack(enforce: false)
-        Packwerk::Package.new(name: 'packs/orchestrator', config: { 'enforce_architecture' => enforce, 'layer' => 'orchestrator' })
+        Packwerk::Package.new(name: 'packs/orchestrator', config: { 'enforce_layers' => enforce, 'layer' => 'orchestrator' })
       end
 
       def utility_pack(enforce: false)
-        Packwerk::Package.new(name: 'packs/utility', config: { 'enforce_architecture' => enforce, 'layer' => 'utility' })
+        Packwerk::Package.new(name: 'packs/utility', config: { 'enforce_layers' => enforce, 'layer' => 'utility' })
       end
 
       setup do
@@ -40,7 +40,7 @@ module Packwerk
       end
 
       test 'ignores if origin package is not enforcing' do
-        checker = architecture_checker
+        checker = layer_checker
         reference = build_reference(
           source_package: utility_pack(enforce: false),
           destination_package: orchestrator_pack(enforce: false)
@@ -50,7 +50,7 @@ module Packwerk
       end
 
       test 'is an invalid reference if destination pack is above source package' do
-        checker = architecture_checker
+        checker = layer_checker
         reference = build_reference(
           source_package: utility_pack(enforce: true),
           destination_package: orchestrator_pack(enforce: false)
@@ -60,9 +60,9 @@ module Packwerk
       end
 
       test 'infers layer based on root directory' do
-        orchestrator_pack = Packwerk::Package.new(name: 'orchestrator/some_pack', config: { 'enforce_architecture' => true })
-        utility_pack = Packwerk::Package.new(name: 'utility/some_other_pack', config: { 'enforce_architecture' => true })
-        checker = architecture_checker
+        orchestrator_pack = Packwerk::Package.new(name: 'orchestrator/some_pack', config: { 'enforce_layers' => true })
+        utility_pack = Packwerk::Package.new(name: 'utility/some_other_pack', config: { 'enforce_layers' => true })
+        checker = layer_checker
         reference = build_reference(
           source_package: utility_pack,
           destination_package: orchestrator_pack
@@ -74,9 +74,9 @@ module Packwerk
       end
 
       test 'allows layer setting to override root directory location' do
-        orchestrator_pack = Packwerk::Package.new(name: 'orchestrator/some_pack', config: { 'layer' => 'specification', 'enforce_architecture' => true })
-        utility_pack = Packwerk::Package.new(name: 'utility/some_other_pack', config: { 'enforce_architecture' => true })
-        checker = architecture_checker
+        orchestrator_pack = Packwerk::Package.new(name: 'orchestrator/some_pack', config: { 'layer' => 'specification', 'enforce_layers' => true })
+        utility_pack = Packwerk::Package.new(name: 'utility/some_other_pack', config: { 'enforce_layers' => true })
+        checker = layer_checker
         reference = build_reference(
           source_package: utility_pack,
           destination_package: orchestrator_pack
@@ -88,7 +88,7 @@ module Packwerk
       end
 
       test 'is not an invalid reference if destination pack is below source package' do
-        checker = architecture_checker
+        checker = layer_checker
         reference = build_reference(
           source_package: orchestrator_pack(enforce: true),
           destination_package: utility_pack(enforce: false)
@@ -103,10 +103,10 @@ module Packwerk
           destination_package: orchestrator_pack(enforce: false)
         )
 
-        assert_equal architecture_checker.message(reference), <<~MSG.chomp
-          Architecture layer violation: '::SomeName' belongs to 'packs/orchestrator', whose architecture layer type is "orchestrator."
-          This constant cannot be referenced by 'packs/utility', whose architecture layer type is "utility."
-          Packs in a lower layer may not access packs in a higher layer. See the `architecture_layers` in packwerk.yml. Current hierarchy:
+        assert_equal layer_checker.message(reference), <<~MSG.chomp
+          Layer violation: '::SomeName' belongs to 'packs/orchestrator', whose layer type is "orchestrator."
+          This constant cannot be referenced by 'packs/utility', whose layer type is "utility."
+          Packs in a lower layer may not access packs in a higher layer. See the `layers` in packwerk.yml. Current hierarchy:
           - orchestrator
           - business_domain
           - platform
@@ -121,8 +121,8 @@ module Packwerk
       private
 
       sig { returns(Checker) }
-      def architecture_checker
-        Packwerk::Architecture::Checker.new
+      def layer_checker
+        Packwerk::Layer::Checker.new
       end
     end
   end

--- a/test/unit/layer/config_test.rb
+++ b/test/unit/layer/config_test.rb
@@ -1,0 +1,67 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Packwerk
+  module Layer
+    class ConfigTest < Minitest::Test
+      extend T::Sig
+      include FactoryHelper
+      include RailsApplicationFixtureHelper
+
+      def write_config
+        write_app_file('packwerk.yml', <<~YML)
+          layers:
+            - orchestrator
+            - business_domain
+        YML
+      end
+
+      def write_architecture_config
+        write_app_file('packwerk.yml', <<~YML)
+          architecture_layers:
+            - orchestrator
+            - business_domain
+        YML
+      end
+
+      setup do
+        setup_application_fixture
+        use_template(:minimal)
+        write_config
+      end
+
+      teardown do
+        teardown_application_fixture
+      end
+
+      test 'determines correct keys' do
+        assert config_instance.layers_key_configured?
+        assert_equal config_instance.layers_key, 'layers'
+        assert_equal config_instance.violation_key, 'layer'
+        assert_equal config_instance.enforce_key, 'enforce_layers'
+      end
+
+      test 'finds the layers' do
+        assert_equal config_instance.layers_list, %w[orchestrator business_domain]
+      end
+
+      test 'determines architecture keys' do
+        write_architecture_config
+        refute config_instance.layers_key_configured?
+        assert_equal config_instance.layers_key, 'architecture_layers'
+        assert_equal config_instance.violation_key, 'architecture'
+        assert_equal config_instance.enforce_key, 'enforce_architecture'
+        assert_equal config_instance.layers_list, %w[orchestrator business_domain]
+      end
+
+      private
+
+      sig { returns(Config) }
+      def config_instance
+        Packwerk::Layer::Config.new
+      end
+    end
+  end
+end

--- a/test/unit/layer/layers_test.rb
+++ b/test/unit/layer/layers_test.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Packwerk
+  module Layer
+    class LayersTest < Minitest::Test
+      extend T::Sig
+      include FactoryHelper
+      include RailsApplicationFixtureHelper
+
+      def write_config
+        write_app_file('packwerk.yml', <<~YML)
+          layers:
+            - orchestrator
+            - business_domain
+        YML
+      end
+
+      setup do
+        setup_application_fixture
+        use_template(:minimal)
+        write_config
+      end
+
+      teardown do
+        teardown_application_fixture
+      end
+
+      test 'finds the configured layers' do
+        assert_equal layers_class.names, Set.new(%w[orchestrator business_domain])
+      end
+
+      private
+
+      sig { returns(Layers) }
+      def layers_class
+        Packwerk::Layer::Layers.new
+      end
+    end
+  end
+end

--- a/test/unit/layer/validator_test.rb
+++ b/test/unit/layer/validator_test.rb
@@ -4,7 +4,7 @@
 require 'test_helper'
 
 module Packwerk
-  module Architecture
+  module Layer
     class ValidatorTest < Minitest::Test
       extend T::Sig
       include ApplicationFixtureHelper
@@ -12,7 +12,7 @@ module Packwerk
 
       def write_config
         write_app_file('packwerk.yml', <<~YML)
-          architecture_layers:
+          layers:
             - package
             - utility
         YML
@@ -28,7 +28,7 @@ module Packwerk
         teardown_application_fixture
       end
 
-      test 'call returns no error if enforce_architecture is unset' do
+      test 'call returns no error if enforce_layers is unset' do
         write_app_file('packwerk.yml', <<~YML)
           {}
         YML
@@ -38,16 +38,16 @@ module Packwerk
       end
 
       test 'call returns an error for invalid enforce_visibility value' do
-        merge_into_app_yaml_file('package.yml', { 'enforce_architecture' => 'yes, please.' })
+        merge_into_app_yaml_file('package.yml', { 'enforce_layers' => 'yes, please.' })
 
         result = validator.call(package_set, config)
 
         refute result.ok?
-        assert_match(/Invalid 'enforce_architecture' option/, result.error_value)
+        assert_match(/Invalid 'enforce_layers' option/, result.error_value)
       end
 
-      test 'call returns success when enforce_architecture is set to strict' do
-        merge_into_app_yaml_file('package.yml', { 'enforce_architecture' => 'strict', 'layer' => 'utility' })
+      test 'call returns success when enforce_layers is set to strict' do
+        merge_into_app_yaml_file('package.yml', { 'enforce_layers' => 'strict', 'layer' => 'utility' })
 
         result = validator.call(package_set, config)
         assert result.ok?
@@ -62,53 +62,53 @@ module Packwerk
         assert_match(/Invalid 'layer' option in.*?package.yml": "blah". Must be one of \["package", "utility"\]/, result.error_value)
       end
 
-      # We return no error here because it's possible we want to set layers for things so consuming packages can enforce their architecture
+      # We return no error here because it's possible we want to set layers for things so consuming packages can enforce their layer
       # without the publishing package needing to enforce it.
-      test 'call returns no error if a layer is set with enforce_architecture not on' do
+      test 'call returns no error if a layer is set with enforce_layers not on' do
         merge_into_app_yaml_file('package.yml', { 'layer' => 'utility' })
 
         result = validator.call(package_set, config)
         assert result.ok?
       end
 
-      test 'call returns an error if a layer is unset with enforce_architecture on' do
-        merge_into_app_yaml_file('package.yml', { 'enforce_architecture' => true })
+      test 'call returns an error if a layer is unset with enforce_layers on' do
+        merge_into_app_yaml_file('package.yml', { 'enforce_layers' => true })
 
         result = validator.call(package_set, config)
 
         refute result.ok?
-        assert_match(/Invalid 'layer' option in.*?package.yml": nil. `layer` must be set if `enforce_architecture` is on./, result.error_value)
+        assert_match(/Invalid 'layer' option in.*?package.yml": nil. `layer` must be set if `enforce_layers` is on./, result.error_value)
       end
 
-      test 'call returns an error if enforce_architecture is set without layers specified' do
+      test 'call returns an error if enforce_layers is set without layers specified' do
         write_app_file('packwerk.yml', <<~YML)
           {}
         YML
-        merge_into_app_yaml_file('package.yml', { 'enforce_architecture' => true })
+        merge_into_app_yaml_file('package.yml', { 'enforce_layers' => true })
 
         result = validator.call(package_set, config)
 
         refute result.ok?
 
-        assert_match(/Cannot set 'enforce_architecture' option in.*?package.yml" until `architectural_layers` have been specified in `packwerk.yml`/, result.error_value)
+        assert_match(/Cannot set 'enforce_layers' option in.*?package.yml" until `layers` have been specified in `packwerk.yml`/, result.error_value)
       end
 
       test 'call returns no error for valid layer value' do
-        merge_into_app_yaml_file('package.yml', { 'enforce_architecture' => true, 'layer' => 'utility' })
+        merge_into_app_yaml_file('package.yml', { 'enforce_layers' => true, 'layer' => 'utility' })
 
         result = validator.call(package_set, config)
         assert result.ok?
       end
 
       test 'call returns no error for no layer value if layer is implied by root location' do
-        merge_into_app_yaml_file('utility/package.yml', { 'enforce_architecture' => true })
+        merge_into_app_yaml_file('utility/package.yml', { 'enforce_layers' => true })
         result = validator.call(package_set, config)
         assert result.ok?
       end
 
-      sig { returns(Packwerk::Architecture::Validator) }
+      sig { returns(Packwerk::Layer::Validator) }
       def validator
-        @validator ||= Packwerk::Architecture::Validator.new
+        @validator ||= Packwerk::Layer::Validator.new
       end
     end
   end

--- a/test/unit/layer/validator_test.rb
+++ b/test/unit/layer/validator_test.rb
@@ -166,13 +166,13 @@ module Packwerk
         assert result.ok?
       end
 
-      test 'call permitted keys' do 
-        assert_equal validator.permitted_keys, ['enforce_layers', 'layer']
+      test 'call permitted keys' do
+        assert_equal validator.permitted_keys, %w[enforce_layers layer]
       end
 
-      test 'call permitted keys when architecture' do 
+      test 'call permitted keys when architecture' do
         write_architecture_config
-        assert_equal validator.permitted_keys, ['enforce_architecture', 'layer']
+        assert_equal validator.permitted_keys, %w[enforce_architecture layer]
       end
 
       sig { returns(Packwerk::Layer::Validator) }


### PR DESCRIPTION
## Background
It was decided that `architecture` isn't a great name for a violation because most of the violation types can be seen as architecture violations.

## Changes
A new violation type, `layer`, is added. `architecture` should be considered deprecated.


|   | Layer Violation |  Architecture Violation |
|--|---------------|------------------------|
| Status | New  | Deprecated |
|packwerk.yml key| layers | architecture_layers|
|package.yml enforcement| enforce_layers | enforce_architecture |
|package_todo violation label | layer | architecture |


## Release plan
- publish this PR as v0.2.0. It offers backward compatibility with the now deprecated `architecture` violation
- a subsequent PR will completely remove `architecture` violation support
- gems that rely on the `architecture` naming will get updated
   - [pack_stats](https://github.com/rubyatscale/pack_stats)
   - [packs](https://github.com/rubyatscale/packs)
   - [parse_packwerk](https://github.com/rubyatscale/parse_packwerk)
   - [visualize_packs](https://github.com/rubyatscale/visualize_packs)
 - https://github.com/alexevanczuk/packs will also need a PR that that mimics this PR's functionality.  