### PR TITLE
bumping to version 0.3.0 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk-extensions (0.2.0)
+    packwerk-extensions (0.3.0)
       packwerk (>= 2.2.1)
       railties (>= 6.0.0)
       sorbet-runtime

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packwerk-extensions'
-  spec.version       = '0.2.0'
+  spec.version       = '0.3.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Renaming `folder_visiblity` to `folder_privacy` is a breaking change.