### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`packwerk-extensions` provides checker extensions for [packwerk](https://github.com/Shopify/packwerk) 3, a gradual modularization platform for Ruby. It ships `privacy`, `visibility`, `folder_privacy`, and `layer` checkers that enforce boundaries between packages.
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (minitest)
+bundle exec rake test
+
+# Run a single test file
+bundle exec ruby -Ilib -Itest test/path/to/test.rb
+
+# Lint
+bundle exec rubocop
+bundle exec rubocop -a  # auto-correct
+
+# Type checking (Sorbet)
+bundle exec srb tc
+```
+
+## Architecture
+
+- `lib/packwerk/` — checker implementations, each as a class that implements the packwerk checker interface
+- `test/` — minitest tests; `test/fixtures/` holds sample Rails app structures used in tests
+- Each checker (e.g. `privacy.rb`, `visibility.rb`, `layer_checker.rb`) reads `package.yml` metadata and decides whether a reference crosses a boundary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.