### PR TITLE
Require sorbet-runtime from each checker entrypoint

### DIFF
--- a/lib/packwerk/folder_privacy/checker.rb
+++ b/lib/packwerk/folder_privacy/checker.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'sorbet-runtime'
 require 'packwerk/folder_privacy/package'
 require 'packwerk/folder_privacy/validator'
 

--- a/lib/packwerk/layer/checker.rb
+++ b/lib/packwerk/layer/checker.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'sorbet-runtime'
 require 'packwerk/layer/config'
 require 'packwerk/layer/layers'
 require 'packwerk/layer/package'

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'sorbet-runtime'
 require 'packwerk/privacy/package'
 require 'packwerk/privacy/validator'
 

--- a/lib/packwerk/visibility/checker.rb
+++ b/lib/packwerk/visibility/checker.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require 'sorbet-runtime'
 require 'packwerk/visibility/package'
 require 'packwerk/visibility/validator'
 


### PR DESCRIPTION
## Summary

- `packwerk` 3.3.0 dropped its runtime dependency on `sorbet-runtime`
- The README documents adding individual checkers to `packwerk.yml`'s `require:` list (e.g. `- packwerk/privacy/checker`), which bypasses `lib/packwerk-extensions.rb` — the only place currently calling `require 'sorbet-runtime'`
- Without `sorbet-runtime` preloaded, evaluating a checker file hits `extend T::Sig` / `T.let` before `T` exists and fails with `uninitialized constant Packwerk::Privacy::T (NameError)`

## Fix

Add `require 'sorbet-runtime'` at the top of each documented entrypoint:

- `lib/packwerk/privacy/checker.rb`
- `lib/packwerk/visibility/checker.rb`
- `lib/packwerk/folder_privacy/checker.rb`
- `lib/packwerk/layer/checker.rb`

The require cascades through `package.rb` / `validator.rb` (and `config.rb` / `layers.rb` for `layer`), which also use `T::` constants. `sorbet-runtime` is already declared as a runtime gemspec dependency, so it's always in the bundle. Existing umbrella entrypoint and test helper continue to work unchanged.

## Reproduction

Before this change, with packwerk 3.3.0 in the bundle:

```bash
ruby -Ilib -rpackwerk -e "require 'packwerk/privacy/checker'"
# => lib/packwerk/privacy/package.rb:7: uninitialized constant Packwerk::Privacy::T (NameError)
```

After:

```bash
ruby -Ilib -rpackwerk -e "require 'packwerk/privacy/checker'"
# => exits 0
```