### PR TITLE
Add Dependabot config for monthly grouped bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      bundler:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds Dependabot version updates for the gem's Ruby dependencies.

- **Ecosystem:** `bundler` (at the repo root)
- **Schedule:** monthly
- **Grouping:** a single `bundler` group matching `*`, so all dependency updates land in one batched PR rather than one PR per gem.
