### PR TITLE
Migrate tests off sorbet-runtime and replace type-erasure casts with total methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,6 @@ DEPENDENCIES
   rubocop-gusto
   rubocop-sorbet!
   sorbet
-  sorbet-static
   tapioca
 
 BUNDLED WITH

--- a/lib/packwerk/privacy/checker.rb
+++ b/lib/packwerk/privacy/checker.rb
@@ -25,7 +25,7 @@ module Packwerk
             publicized_locations[location] = check_for_publicized_sigil(location)
           end
 
-          publicized_locations[location] #: as !nil
+          publicized_locations.fetch(location)
         end
 
         #: (String location) -> bool
@@ -35,8 +35,7 @@ module Packwerk
 
         #: (Array[String] lines) -> bool
         def content_contains_sigil?(lines)
-          first_lines = lines[0..4] #: as !nil
-          first_lines.any? { |l| l =~ PUBLICIZED_SIGIL_REGEX }
+          lines.first(5).any? { |l| l =~ PUBLICIZED_SIGIL_REGEX }
         end
       end
 

--- a/packwerk-extensions.gemspec
+++ b/packwerk-extensions.gemspec
@@ -34,6 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-gusto'
   spec.add_development_dependency 'sorbet'
-  spec.add_development_dependency 'sorbet-static'
   spec.add_development_dependency 'tapioca'
 end

--- a/test/integration/extension_test.rb
+++ b/test/integration/extension_test.rb
@@ -6,8 +6,6 @@ require 'test_helper'
 module Packwerk
   module Privacy
     class ExtensionTest < Minitest::Test
-      extend T::Sig
-
       include ApplicationFixtureHelper
 
       setup do
@@ -23,7 +21,8 @@ module Packwerk
         Packwerk::Checker.all
         assert_equal(Packwerk::Checker.all.count, 5)
         found_checker = Packwerk::Checker.all.any? do |checker|
-          T.unsafe(checker).is_a?(Packwerk::Privacy::Checker)
+          untyped_checker = checker #: as untyped
+          untyped_checker.is_a?(Packwerk::Privacy::Checker)
         end
         assert found_checker
       end

--- a/test/integration/extension_test.rb
+++ b/test/integration/extension_test.rb
@@ -20,11 +20,7 @@ module Packwerk
         use_template(:extended)
         Packwerk::Checker.all
         assert_equal(Packwerk::Checker.all.count, 5)
-        found_checker = Packwerk::Checker.all.any? do |checker|
-          untyped_checker = checker #: as untyped
-          untyped_checker.is_a?(Packwerk::Privacy::Checker)
-        end
-        assert found_checker
+        assert(Packwerk::Checker.all.any?(Packwerk::Privacy::Checker))
       end
     end
   end

--- a/test/integration/extension_with_unrecognized_config_test.rb
+++ b/test/integration/extension_with_unrecognized_config_test.rb
@@ -20,11 +20,7 @@ module Packwerk
         use_template(:with_unrecognized_config)
         Packwerk::Checker.all
         assert_equal(Packwerk::Checker.all.count, 5)
-        found_checker = Packwerk::Checker.all.any? do |checker|
-          untyped_checker = checker #: as untyped
-          untyped_checker.is_a?(Packwerk::Privacy::Checker)
-        end
-        assert found_checker
+        assert(Packwerk::Checker.all.any?(Packwerk::Privacy::Checker))
       end
     end
   end

--- a/test/integration/extension_with_unrecognized_config_test.rb
+++ b/test/integration/extension_with_unrecognized_config_test.rb
@@ -6,8 +6,6 @@ require 'test_helper'
 module Packwerk
   module Privacy
     class ExtensionWithUnrecognizedConfigTest < Minitest::Test
-      extend T::Sig
-
       include ApplicationFixtureHelper
 
       setup do
@@ -23,7 +21,8 @@ module Packwerk
         Packwerk::Checker.all
         assert_equal(Packwerk::Checker.all.count, 5)
         found_checker = Packwerk::Checker.all.any? do |checker|
-          T.unsafe(checker).is_a?(Packwerk::Privacy::Checker)
+          untyped_checker = checker #: as untyped
+          untyped_checker.is_a?(Packwerk::Privacy::Checker)
         end
         assert found_checker
       end

--- a/test/support/application_fixture_helper.rb
+++ b/test/support/application_fixture_helper.rb
@@ -77,7 +77,7 @@ module ApplicationFixtureHelper
   end
 
   def copy_dir(path)
-    root = FileUtils.mkdir_p(fixture_path).last #: as !nil
+    root = FileUtils.mkdir_p(fixture_path).fetch(-1)
     FileUtils.cp_r("#{path}/.", root)
     @app_dir = root
   end

--- a/test/support/application_fixture_helper.rb
+++ b/test/support/application_fixture_helper.rb
@@ -1,13 +1,10 @@
 # typed: true
 # frozen_string_literal: true
 
+# @requires_ancestor: Minitest::Runnable
 module ApplicationFixtureHelper
   TEMP_FIXTURE_DIR = ROOT.join('tmp', 'fixtures').to_s
   DEFAULT_TEMPLATE = :minimal
-
-  extend T::Helpers
-
-  requires_ancestor { Kernel }
 
   def setup_application_fixture
     @old_working_dir = Dir.pwd
@@ -80,13 +77,12 @@ module ApplicationFixtureHelper
   end
 
   def copy_dir(path)
-    root = FileUtils.mkdir_p(fixture_path).last
-    FileUtils.cp_r("#{path}/.", T.must(root))
+    root = FileUtils.mkdir_p(fixture_path).last #: as !nil
+    FileUtils.cp_r("#{path}/.", root)
     @app_dir = root
   end
 
   def fixture_path
-    T.bind(self, Minitest::Runnable)
     File.join(TEMP_FIXTURE_DIR, "#{name}-#{Time.now.strftime('%Y_%m_%d_%H_%M_%S')}")
   end
 end

--- a/test/unit/folder_privacy/checker_test.rb
+++ b/test/unit/folder_privacy/checker_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module FolderPrivacy
     class CheckerTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -61,7 +60,7 @@ module Packwerk
 
       private
 
-      sig { returns(Checker) }
+      #: -> Checker
       def folder_privacy_checker
         FolderPrivacy::Checker.new
       end

--- a/test/unit/folder_privacy/validator_test.rb
+++ b/test/unit/folder_privacy/validator_test.rb
@@ -9,7 +9,6 @@ require 'fixtures/skeleton/components/timeline/app/models/private_thing'
 module Packwerk
   module FolderPrivacy
     class ValidatorTest < Minitest::Test
-      extend T::Sig
       include ApplicationFixtureHelper
       include RailsApplicationFixtureHelper
 
@@ -40,7 +39,7 @@ module Packwerk
         assert result.ok?
       end
 
-      sig { returns(Packwerk::FolderPrivacy::Validator) }
+      #: -> Packwerk::FolderPrivacy::Validator
       def validator
         @validator ||= Packwerk::FolderPrivacy::Validator.new
       end

--- a/test/unit/layer/checker_architecture_test.rb
+++ b/test/unit/layer/checker_architecture_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Layer
     class CheckerTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -120,7 +119,7 @@ module Packwerk
 
       private
 
-      sig { returns(Checker) }
+      #: -> Checker
       def layer_checker
         Packwerk::Layer::Checker.new
       end

--- a/test/unit/layer/checker_test.rb
+++ b/test/unit/layer/checker_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Layer
     class CheckerTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -124,7 +123,7 @@ module Packwerk
 
       private
 
-      sig { returns(Checker) }
+      #: -> Checker
       def layer_checker
         Packwerk::Layer::Checker.new
       end

--- a/test/unit/layer/config_test.rb
+++ b/test/unit/layer/config_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Layer
     class ConfigTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -58,7 +57,7 @@ module Packwerk
 
       private
 
-      sig { returns(Config) }
+      #: -> Config
       def config_instance
         Packwerk::Layer::Config.new
       end

--- a/test/unit/layer/layers_test.rb
+++ b/test/unit/layer/layers_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Layer
     class LayersTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -34,7 +33,7 @@ module Packwerk
 
       private
 
-      sig { returns(Layers) }
+      #: -> Layers
       def layers_class
         Packwerk::Layer::Layers.new
       end

--- a/test/unit/layer/validator_test.rb
+++ b/test/unit/layer/validator_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Layer
     class ValidatorTest < Minitest::Test
-      extend T::Sig
       include ApplicationFixtureHelper
       include RailsApplicationFixtureHelper
 
@@ -175,7 +174,7 @@ module Packwerk
         assert_equal validator.permitted_keys, %w(enforce_architecture layer)
       end
 
-      sig { returns(Packwerk::Layer::Validator) }
+      #: -> Packwerk::Layer::Validator
       def validator
         @validator ||= Packwerk::Layer::Validator.new
       end

--- a/test/unit/privacy/checker_test.rb
+++ b/test/unit/privacy/checker_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Privacy
     class CheckerTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -169,7 +168,7 @@ module Packwerk
 
       private
 
-      sig { returns(Checker) }
+      #: -> Checker
       def privacy_checker
         Privacy::Checker.new
       end

--- a/test/unit/privacy/package_test.rb
+++ b/test/unit/privacy/package_test.rb
@@ -6,8 +6,6 @@ require 'test_helper'
 module Packwerk
   module Privacy
     class PackageTest < Minitest::Test
-      extend T::Sig
-
       include RailsApplicationFixtureHelper
 
       setup do
@@ -19,7 +17,7 @@ module Packwerk
         teardown_application_fixture
       end
 
-      sig { returns(Package) }
+      #: -> Package
       def privacy_package
         Package.from(@package)
       end

--- a/test/unit/privacy/validator_test.rb
+++ b/test/unit/privacy/validator_test.rb
@@ -9,7 +9,6 @@ require 'fixtures/skeleton/components/timeline/app/models/private_thing'
 module Packwerk
   module Privacy
     class ValidatorTest < Minitest::Test
-      extend T::Sig
       include ApplicationFixtureHelper
       include RailsApplicationFixtureHelper
 
@@ -128,7 +127,7 @@ module Packwerk
 
       private
 
-      sig { returns(ApplicationValidator) }
+      #: -> ApplicationValidator
       def validator
         @validator ||= ApplicationValidator.new
       end

--- a/test/unit/visibility/checker_test.rb
+++ b/test/unit/visibility/checker_test.rb
@@ -6,7 +6,6 @@ require 'test_helper'
 module Packwerk
   module Visibility
     class CheckerTest < Minitest::Test
-      extend T::Sig
       include FactoryHelper
       include RailsApplicationFixtureHelper
 
@@ -59,7 +58,7 @@ module Packwerk
 
       private
 
-      sig { returns(Checker) }
+      #: -> Checker
       def visibility_checker
         Visibility::Checker.new
       end

--- a/test/unit/visibility/validator_test.rb
+++ b/test/unit/visibility/validator_test.rb
@@ -9,7 +9,6 @@ require 'fixtures/skeleton/components/timeline/app/models/private_thing'
 module Packwerk
   module Visibility
     class ValidatorTest < Minitest::Test
-      extend T::Sig
       include ApplicationFixtureHelper
       include RailsApplicationFixtureHelper
 
@@ -69,7 +68,7 @@ module Packwerk
         assert result.ok?
       end
 
-      sig { returns(Packwerk::Visibility::Validator) }
+      #: -> Packwerk::Visibility::Validator
       def validator
         @validator ||= Packwerk::Visibility::Validator.new
       end


### PR DESCRIPTION
## Summary

Completes the `sorbet-runtime` removal started in #68 by migrating the **test suite** off Sorbet's runtime DSL, and replaces the remaining type-erasure / non-nil casts (in both the tests and `lib/`) with total methods.

#68 migrated `lib/` to RBS comments and dropped the `sorbet-runtime` dependency, but the tests still used `extend T::Sig`, `sig {}`, `T.must`, `T.unsafe`, and `T.bind`. That only kept working because packwerk transitively loaded `sorbet-runtime`. **packwerk 3.3.0 drops sorbet-runtime**, so the suite now fails with `uninitialized constant T` (surfaced by the Dependabot bump in #70). Rather than re-introduce a `sorbet-runtime` dependency — even for development — this finishes the migration in `test/` the same way as `lib/`.

## Changes

**Migrate `test/` off the Sorbet runtime DSL**
- Translate `sig` blocks to `#:` RBS comments and remove `extend T::Sig` across the unit and integration tests.
- In the fixture helper, replace `extend T::Helpers` + `requires_ancestor { Kernel }` + `T.bind(self, Minitest::Runnable)` with a single `# @requires_ancestor: Minitest::Runnable` annotation (which provides `name` plus `Kernel`).

**Replace type-erasure / non-nil casts with total methods (no `T.must`/`T.unsafe`, no `#: as` casts left anywhere)**
- Integration specs: `Packwerk::Checker.all.any?(Packwerk::Privacy::Checker)` (uses `===` as a pattern) instead of casting the abstract `Packwerk::Checker` element to `untyped` to call `is_a?`.
- Fixture helper: `FileUtils.mkdir_p(...).fetch(-1)` instead of `.last` with a `#: as !nil` cast.
- `lib/packwerk/privacy/checker.rb`: `publicized_locations.fetch(location)` and `lines.first(5)` instead of `[…]` / `[0..4]` with `#: as !nil` casts.

**Dependencies**
- Drop the redundant `sorbet-static` dev dependency — the `sorbet` gem already depends on it.

## Verification

- `bundle exec srb tc` → No errors
- `bundle exec rake test` → 88 runs, 0 failures
- `bundle exec rubocop` → no offenses

## Note

This should merge before the Dependabot bump (#70), which needs this fix on `main` to pass CI on packwerk 3.3.0.
